### PR TITLE
chore: PR 사이드바 자동 설정 기능 추가

### DIFF
--- a/.github/workflows/setup-open-pr.yml
+++ b/.github/workflows/setup-open-pr.yml
@@ -1,0 +1,278 @@
+name: Setup Opened PR
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+
+  setup_pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+
+    steps:
+      - name: Set assignees
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { pull_request: pr, repository } = context.payload;
+            const author = pr.user.login;
+
+            await github.rest.issues.addAssignees({
+              owner: repository.owner.login,
+              repo: repository.name,
+              issue_number: pr.number,
+              assignees: [author],
+            });
+
+      - name: Set reviewers
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { pull_request: pr, repository } = context.payload;
+            const author = pr.user.login;
+
+            const feTeam = ['ohgus', 'AHHYUNJU', 'aydenote', 'jeongyou'];
+            const beTeam = ['threepebbles', 'goohong', 'cookie-meringue', 'DongchannN'];
+
+            const isAuthorFE = feTeam.includes(author);
+            const isAuthorBE = beTeam.includes(author);
+            const reviewers = (isAuthorFE ? feTeam : isAuthorBE ? beTeam : []).filter(r => r !== author);
+
+            if (reviewers.length) {
+              await github.rest.pulls.requestReviewers({
+                owner: repository.owner.login,
+                repo: repository.name,
+                pull_number: pr.number,
+                reviewers,
+              });
+            }
+
+      - name: Set labels
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { pull_request: pr, repository } = context.payload;
+            
+            const labels = [];
+            
+            // 1. branch prefix 기반 라벨 추가
+            const branch = pr.head.ref;
+            const branchLabelMap = {
+              'feature/': 'feature',
+              'fix/': 'fix',
+              'refactor/': 'refactor',
+              'chore/': 'chore',
+              'hotfix/': 'hotfix',
+            };
+            const branchPrefix = Object.keys(branchLabelMap).find(p => branch.startsWith(p));
+            if (branchPrefix) labels.push(branchLabelMap[branchPrefix]);
+            
+            // 2. author 기반 라벨 추가
+            const feTeam = ['ohgus', 'AHHYUNJU', 'aydenote', 'jeongyou'];
+            const beTeam = ['threepebbles', 'goohong', 'cookie-meringue', 'DongchannN'];
+            
+            const author = pr.user.login;
+            const authorLabel = feTeam.includes(author) ? 'frontend' : beTeam.includes(author) ? 'backend' : null;
+            if (authorLabel) labels.push(authorLabel);
+            
+            if (labels.length) {
+              await github.rest.issues.addLabels({
+                owner: repository.owner.login,
+                repo: repository.name,
+                issue_number: pr.number,
+                labels,
+              });
+            }
+
+      - name: Set Projects
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_V2_TOKEN }}
+          script: |
+            // GitHub Actions에서 전달 받은 PR 정보
+            const { pull_request: pr } = context.payload;
+            
+            // Project v2 ID
+            const projectNodeId = 'PVT_kwDOA_44FM4A9rer';
+            
+            const fieldData = await github.graphql(`
+              query {
+                node(id: "${projectNodeId}") {
+                  ... on ProjectV2 {
+                    fields(first: 50) {
+                      nodes {
+                        __typename
+            
+                        ... on ProjectV2FieldCommon {
+                          id
+                          name
+                        }
+            
+                        ... on ProjectV2SingleSelectField {
+                          options {
+                            id
+                            name
+                          }
+                        }
+            
+                        ... on ProjectV2IterationField {
+                          configuration {
+                            __typename
+                            ... on ProjectV2IterationFieldConfiguration {
+                              iterations {
+                                id
+                                startDate
+                                duration
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            `);
+
+            const fields = fieldData.node.fields.nodes;
+            
+            // 1. Issue를 Project 아이템으로 추가
+            const addItemResponse = await github.graphql(`
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                  item { id }
+                }
+              }
+            `, {
+              projectId: projectNodeId,
+              contentId: pr.node_id,
+            });
+
+            // 2. Status 필드 In Progress로 설정
+            const itemId = addItemResponse.addProjectV2ItemById.item.id;
+            const statusField = fields.find(f =>
+              f.__typename === 'ProjectV2SingleSelectField' &&
+              f.name?.toLowerCase() === 'status'
+            );
+            const statusFieldId = statusField?.id;
+            const inProgressOptionId = statusField?.options?.find(o => o.name.toLowerCase() === 'in progress')?.id;
+            
+            if (statusFieldId && inProgressOptionId) {
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId,
+                    itemId: $itemId,
+                    fieldId: $fieldId,
+                    value: { singleSelectOptionId: $optionId }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }
+              `, {
+                projectId: projectNodeId,
+                itemId,
+                fieldId: statusFieldId,
+                optionId: inProgressOptionId,
+              });
+            }
+
+            // 3. Start Date을 today로 설정
+            const startDateField = fields.find(f =>
+              f.__typename === 'ProjectV2Field' &&
+              f.name?.toLowerCase() === 'start date'
+            );
+            const startDateFieldId = startDateField?.id;
+            
+            const today = new Date();
+            const todayISOString = today.toISOString().split('T')[0];
+            
+            if (startDateFieldId) {
+              await github.graphql(`
+                mutation {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: "${projectNodeId}",
+                    itemId: "${itemId}",
+                    fieldId: "${startDateFieldId}",
+                    value: { date: "${todayISOString}" }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }
+              `);
+            }
+            
+            // 4. iteration 설정
+            const iterationField = fields.find(f =>
+              f.__typename === 'ProjectV2IterationField' &&
+              f.configuration?.__typename === 'ProjectV2IterationFieldConfiguration'
+            );
+            const iterationFieldId = iterationField?.id;
+            const iterations = iterationField?.configuration?.iterations ?? [];
+
+            // 오늘이 포함된 iteration 찾기
+            function isDateInRange(start, durationDays) {
+              const startDate = new Date(start);
+              const endDate = new Date(startDate);
+              endDate.setDate(endDate.getDate() + durationDays);
+              return today >= startDate && today < endDate;
+            }
+
+            const matchingIteration = iterations.find(i => isDateInRange(i.startDate, i.duration));
+
+            if (iterationFieldId && matchingIteration) {
+              await github.graphql(`
+                mutation {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: "${projectNodeId}",
+                    itemId: "${itemId}",
+                    fieldId: "${iterationFieldId}",
+                    value: {
+                      iterationId: "${matchingIteration.id}"
+                    }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }
+              `);
+            }
+            
+            // 5. Hierarchy 필드 task로 설정
+            const hierarchyField = fields.find(f =>
+              f.__typename === 'ProjectV2SingleSelectField' &&
+              f.name?.toLowerCase() === 'hierarchy'
+            );
+
+            const hierarchyFieldId = hierarchyField?.id;
+            const taskOptionId = hierarchyField?.options?.find(o => o.name.toLowerCase() === 'task')?.id;
+
+            if (hierarchyFieldId && taskOptionId) {
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId,
+                    itemId: $itemId,
+                    fieldId: $fieldId,
+                    value: { singleSelectOptionId: $optionId }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }
+              `, {
+                projectId: projectNodeId,
+                itemId,
+                fieldId: hierarchyFieldId,
+                optionId: taskOptionId,
+              });
+            }


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
PR 사이드바의 많은 정보를 수기로 입력하고 있음

- Reviewers
- Assignees
- Labels
  - backend/frontend
  - work type (feature, chore, ...)
- Projects
  - Status
  - Spring
  - Start Date
  - Hierarchy

## To-Be
<!-- 변경 사항 -->

PR이 open되거나 reopen되면 자동으로 사이드바에 디폴트 값을 설정합니다.

**정책**
- `Assignees` :
    - PR을 생성한 사람
- `Labels` :
    - PR 생성자를 기반으로 `backend`/`frontend` 라벨 부여
        - Issue 생성자가 백엔드 팀원이면 `backend` 라벨 부여
        - Issue 생성자가 프론트엔드 팀원이면 `frontend` 라벨 부여
    - PR에 올라온 브랜치명의 prefix를 기반으로 작업 타입 라벨 부여
		- `브랜치명 prefix` : `작업 타입 라벨`
            - `feature/` : `feature`
            - `fix/` : `fix`
            - `style/`: `style`
            - `docs/`: `docs`
            - `chore/`: `chore`
            - `refactor`: `refactor`
        - 브랜치명이 `feature/sign-up-#99` 인경우, `feature` 라벨을 자동으로 부여
- `Projects` :
    - `Status`: `In Progress`로 설정
    - `Sprint`: 오늘에 해당하는 iteration 선택
    - `Start date`: 오늘로 설정
    - `Hierarchy`: `task`로 설정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
close #32 