### PR TITLE
fix: Discord PR 알람 기능 트리거 기준 수정

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -2,7 +2,7 @@ name: PR Label-based Discord Notification
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, labeled]
 
 jobs:
   notify-discord:


### PR DESCRIPTION
- [opened, reopened, synchronized] -> [opened, reopened, labeled]

## As-Is
<!-- 문제 상황 정의 -->
기존 트리거 기준: [opened, reopened, synchronized]
PR 생성 후 라벨을 부여했을 때 디스코드에 알림이 오지 않음

## To-Be
<!-- 변경 사항 -->
변경 후 트리거 기준: [opened, reopened, labeled]
PR 생성 후 라벨을 붙여도 디스코드에 알림이 오도록 수정
단, 라벨을 붙였다 뗐다 하면 붙일 때마다 알림 발생함

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
