### PR TITLE
feat: 엔티티 별 레포지토리 생성

### DIFF
--- a/backend/spring-routie/src/main/java/routie/place/repository/PlaceClosedWeekdayRepository.java
+++ b/backend/spring-routie/src/main/java/routie/place/repository/PlaceClosedWeekdayRepository.java
@@ -1,0 +1,9 @@
+package routie.place.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import routie.place.domain.PlaceClosedWeekday;
+
+@Repository
+public interface PlaceClosedWeekdayRepository extends JpaRepository<PlaceClosedWeekday, Long> {
+}

--- a/backend/spring-routie/src/main/java/routie/place/repository/PlaceRepository.java
+++ b/backend/spring-routie/src/main/java/routie/place/repository/PlaceRepository.java
@@ -1,0 +1,9 @@
+package routie.place.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import routie.place.domain.Place;
+
+@Repository
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+}

--- a/backend/spring-routie/src/main/java/routie/routie/repository/RoutiePlaceRepository.java
+++ b/backend/spring-routie/src/main/java/routie/routie/repository/RoutiePlaceRepository.java
@@ -1,0 +1,9 @@
+package routie.routie.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import routie.routie.domain.RoutiePlace;
+
+@Repository
+public interface RoutiePlaceRepository extends JpaRepository<RoutiePlace, Long> {
+}

--- a/backend/spring-routie/src/main/java/routie/routie/repository/RoutieRepository.java
+++ b/backend/spring-routie/src/main/java/routie/routie/repository/RoutieRepository.java
@@ -1,0 +1,9 @@
+package routie.routie.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import routie.routie.domain.Routie;
+
+@Repository
+public interface RoutieRepository extends JpaRepository<Routie, Long> {
+}

--- a/backend/spring-routie/src/main/java/routie/routiespace/repository/RoutieSpaceRepository.java
+++ b/backend/spring-routie/src/main/java/routie/routiespace/repository/RoutieSpaceRepository.java
@@ -1,0 +1,9 @@
+package routie.routiespace.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import routie.routiespace.domain.RoutieSpace;
+
+@Repository
+public interface RoutieSpaceRepository extends JpaRepository<RoutieSpace, Long> {
+}


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 도메인 엔티티들(Place, RoutieSpace, Routie, RoutePlace, PlaceClosedWeekday)에 대한 데이터 접근 계층이 구현되지 않음
- 비즈니스 로직에서 데이터베이스와 상호작용할 수 있는 Repository 인터페이스가 없음
- JPA를 활용한 CRUD 작업 및 커스텀 쿼리 실행이 불가능한 상태

## To-Be
<!-- 변경 사항 -->
- 각 도메인 엔티티별로 JpaRepository를 상속받는 Repository 인터페이스 생성

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [X] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으롷 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #105 