### PR TITLE
refactor: 공통 Input 컴포넌트 리팩터링

### DIFF
--- a/frontend/src/@common/components/Input/Input.tsx
+++ b/frontend/src/@common/components/Input/Input.tsx
@@ -13,7 +13,9 @@ const Input = ({
   id,
   type,
   label,
-  placeholder,
+  placeholder = '',
+  value,
+  onChange,
   variant = 'primary',
   icon,
 }: InputProps) => {
@@ -34,6 +36,8 @@ const Input = ({
           id={id}
           type={type}
           placeholder={placeholder}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
           disabled={variant === 'disabled'}
         />
       </div>

--- a/frontend/src/@common/components/Input/Input.tsx
+++ b/frontend/src/@common/components/Input/Input.tsx
@@ -22,9 +22,11 @@ const Input = ({
 
   return (
     <>
-      <label css={InputLabelStyle} htmlFor={id}>
-        {label}
-      </label>
+      {label && (
+        <label css={InputLabelStyle} htmlFor={id}>
+          {label}
+        </label>
+      )}
       <div css={InputContainerStyle}>
         {iconSrc && <img src={iconSrc} alt="input-icon" css={InputIconStyle} />}
         <input

--- a/frontend/src/@common/components/Input/Input.types.ts
+++ b/frontend/src/@common/components/Input/Input.types.ts
@@ -1,11 +1,13 @@
 import { ComponentProps } from 'react';
 
-export interface InputProps extends ComponentProps<'input'> {
+export interface InputProps
+  extends Omit<ComponentProps<'input'>, 'onChange' | 'value'> {
   id: string;
   type?: string;
   label?: string;
   placeholder?: string;
-  border?: boolean;
+  value: string;
+  onChange: (value: string) => void;
   variant?: InputVariantProps;
   icon?: 'search' | 'clock';
 }


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- label props값이 없는데도 label 태그가 랜더링 되어서 css 스타일링에 label태그가 포함되는 문제 발생
- input 컴포넌트의 props로 value, onChange가 없어서 외부에서 값을 제어할 수 없었음

## To-Be
<!-- 변경 사항 -->
- label props 넘어오지 않았을 때 label조건부 랜더링 할 수 있도록 수정
- input 컴포넌트의 props로 value, onChange 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
value랑 onChange에는 state, setState 핸들러 함수가 넘어온다고 가정하였습니다. 

<!-- merge 시 이슈를 자동으롷 닫고자 할 때 사용
Closes #{이슈번호}
-->
close #107 
