### PR TITLE
chore: dev 환경용 MySQL 설정을 위한 docker-compose.yml 추가

### DIFF
--- a/backend/spring-routie/docker-compose.yml
+++ b/backend/spring-routie/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:8.4.5
     container_name: routie-mysql
     ports:
-      - "3306:3306"
+      - "33060:3306"
     environment:
       MYSQL_ROOT_PASSWORD: routie-root
       MYSQL_DATABASE: routie

--- a/backend/spring-routie/docker-compose.yml
+++ b/backend/spring-routie/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.4.5
+    container_name: routie-mysql
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: routie-root
+      MYSQL_DATABASE: routie
+      MYSQL_USER: routie-user-example
+      MYSQL_PASSWORD: routie-password-example
+    volumes:
+      - routie-mysql-data:/var/lib/mysql
+    restart: unless-stopped
+
+volumes:
+  routie-mysql-data:


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 각자 로컬 환경에서 다양한 방법으로 MySQL을 실행하여 사용 중임

## To-Be
<!-- 변경 사항 -->
- 각자의 로컬 환경에서도 동일한 MySQL 설정, 이미지를 사용하기 위함
- 기대효과: 각자 로컬의 DB 환경 불일치로 발생할 수 있는 오류 가능성 제거

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

close #158 