### PR TITLE
fix: drag 기능을 연결하지 않아 동작되지 않았던 부분 수정

### DIFF
--- a/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import Button from '@/@common/components/Button/Button';
 import Flex from '@/@common/components/Flex/Flex';
 import Header from '@/@common/components/Header/Header';
@@ -5,6 +7,7 @@ import Pill from '@/@common/components/Pill/Pill';
 import Text from '@/@common/components/Text/Text';
 import ToggleSwitch from '@/@common/components/ToggleSwitch/ToggleSwitch';
 import RoutiePlaceCard from '@/domains/routie/components/RoutiePlaceCard/RoutiePlaceCard';
+import { useCardDrag } from '@/domains/routie/hooks/useCardDrag';
 import RoutieSpaceName from '@/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName';
 import theme from '@/styles/theme';
 
@@ -80,6 +83,9 @@ const places = [
   },
 ];
 const Sidebar = () => {
+  const [routie, setRoutie] = useState(places);
+  const getDragProps = useCardDrag(routie, setRoutie);
+
   return (
     <Flex direction="column" width="50rem" gap={1}>
       <Header />
@@ -127,10 +133,12 @@ const Sidebar = () => {
             boxSizing: 'border-box',
           }}
         >
-          {places.map((place, index) => {
+          {routie.map((place, index) => {
             return (
               <>
-                <RoutiePlaceCard key={place.id} {...place} />
+                <div key={place.id} {...getDragProps(index)}>
+                  <RoutiePlaceCard {...place} />
+                </div>
                 {index < places.length - 1 && (
                   <Flex gap={1}>
                     <Text variant="description">도보 15분</Text>


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
Sidebar 컴포넌트에 drag 기능을 연결하지 않아 루티 장소 순서 이동 불가능

## To-Be
<!-- 변경 사항 -->
Sidebar 컴포넌트에 drag 기능 관련 훅 선언 및 사용

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
https://github.com/user-attachments/assets/634450fd-6d68-49ff-80c2-078d4a66c014

## (Optional) Additional Description


<!-- merge 시 이슈를 자동으롷 닫고자 할 때 사용
Closes #{이슈번호}
-->

close #164
