### PR TITLE
refactor: 폼 제출 시 모달 닫히도록 수정, UI 중복 요소 제거, 휴무일 데이터 서버 전송 전 영문 요일 리스트로 변환

### DIFF
--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
@@ -2,6 +2,7 @@ import Flex from '@/@common/components/Flex/Flex';
 import Modal, { ModalProps } from '@/@common/components/Modal/Modal';
 import { useAddPlaceForm } from '@/domains/places/hooks/useAddPlaceForm';
 
+import { getCheckedDaysInEnglish } from '../../utils/getCheckedDaysInEnglish';
 import OptionalInfoSection from '../PlaceFormSection/OptionalInfoSection';
 import RequiredInfoSection from '../PlaceFormSection/RequiredInfoSection';
 
@@ -20,6 +21,16 @@ const AddPlaceModal = ({ isOpen, onClose }: Omit<ModalProps, 'children'>) => {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    const englishClosedDays = getCheckedDaysInEnglish(form.closedDays);
+
+    // TODO: API 요청 로직 연결 예정
+    const payload = {
+      ...form,
+      closedDays: englishClosedDays,
+    };
+
+    handleClose();
   };
 
   return (
@@ -41,7 +52,7 @@ const AddPlaceModal = ({ isOpen, onClose }: Omit<ModalProps, 'children'>) => {
               onToggleDay={handleToggleDay}
             />
           </div>
-          <AddPlaceModalButtons onClose={handleClose} />
+          <AddPlaceModalButtons />
         </Flex>
       </form>
     </Modal>

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModalButtons.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModalButtons.tsx
@@ -2,20 +2,9 @@ import Button from '@/@common/components/Button/Button';
 import Flex from '@/@common/components/Flex/Flex';
 import Text from '@/@common/components/Text/Text';
 
-interface AddPlaceModalButtonsProps {
-  onClose: () => void;
-}
-
-const AddPlaceModalButtons = ({ onClose }: AddPlaceModalButtonsProps) => {
+const AddPlaceModalButtons = () => {
   return (
     <Flex justifyContent="space-between" width="100%" gap={1.6}>
-      <Button type="button" variant="secondary">
-        <Flex width="100%">
-          <Text variant="caption" color="purple" onClick={onClose}>
-            닫기
-          </Text>
-        </Flex>
-      </Button>
       <Button type="submit" variant="primary">
         <Flex width="100%">
           <Text variant="caption" color="white">


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 폼 제출 후 모달이 닫히지 않음
- 상단의 x 버튼과 하단의 닫기 버튼의 기능이 중복됨
- submit 버튼을 눌렀을 때 휴무일 데이터가 전송 타입인 영문 날짜 리스트가 아닌, boolean 리스트로 되어있음

## To-Be
<!-- 변경 사항 -->
- 폼 제출 시 모달 닫히도록 수정
- UI 중복 요소 제거
- 휴무일 데이터 서버 전송 전 영문 요일 리스트로 변환

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으롷 닫고자 할 때 사용
Closes #{이슈번호}
-->

close #167 
