### PR TITLE
chore: 신속한 API 리스트 확인을 위해 swagger 추가

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Restore application.yml
         run: |
           mkdir -p config
-          echo "${{ secrets.APPLICATION_YML_PROD }}" > config/application.yml
+          echo "${{ secrets.APPLICATION_YML_DEV }}" > config/application.yml
 
       - name: Kill existing Spring Process
         run: |

--- a/backend/spring-routie/build.gradle
+++ b/backend/spring-routie/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    
+
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -51,6 +51,9 @@ dependencies {
 
     // h2
     testRuntimeOnly 'com.h2database:h2'
+
+    // springdoc(Swagger)
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.8'
 }
 
 tasks.named('test') {

--- a/backend/spring-routie/src/main/java/routie/auth/config/WebMvcConfig.java
+++ b/backend/spring-routie/src/main/java/routie/auth/config/WebMvcConfig.java
@@ -14,6 +14,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("*")
                 .allowedMethods("*")
-                .allowedHeaders("*");
+                .allowedHeaders("*")
+                .exposedHeaders("Location");
     }
 }

--- a/backend/spring-routie/src/main/java/routie/docs/config/SwaggerConfig.java
+++ b/backend/spring-routie/src/main/java/routie/docs/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package routie.docs.config;
+
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI roomEscapeOpenAPI() {
+        String title = "Routie Docs";
+        String description = "Routie API 문서입니다.";
+
+        Info info = new Info().title(title).description(description).version("0.0.1");
+
+        return new OpenAPI().info(info);
+    }
+}
+


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
notion에 작성한 API문서와 실제 구현된 API 개수, 경로가 일치하지 않음

## To-Be
<!-- 변경 사항 -->
작성된 API의 리스트를 빠르게 확인하기 위해 swagger 사용

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으롷 닫고자 할 때 사용
Closes #{이슈번호}
-->
