### PR TITLE
fix: 루티 상세 조회 기능 API 명세에 맞게 수정

### DIFF
--- a/backend/spring-routie/src/main/java/routie/routie/controller/dto/response/RoutieReadResponse.java
+++ b/backend/spring-routie/src/main/java/routie/routie/controller/dto/response/RoutieReadResponse.java
@@ -1,18 +1,24 @@
 package routie.routie.controller.dto.response;
 
 import java.util.List;
+import routie.place.domain.MovingStrategy;
 import routie.routie.domain.Routie;
 import routie.routie.domain.RoutiePlace;
+import routie.routie.domain.route.Route;
 
 public record RoutieReadResponse(
         Long id,
-        List<RoutiePlaceResponse> places
+        List<RoutiePlaceResponse> places,
+        List<RouteResponse> routes
 ) {
-    public static RoutieReadResponse from(final Routie routie) {
+    public static RoutieReadResponse from(final Routie routie, final List<Route> routes) {
         return new RoutieReadResponse(
                 routie.getId(),
                 routie.getRoutiePlaces().stream()
                         .map(RoutiePlaceResponse::from)
+                        .toList(),
+                routes.stream()
+                        .map(RouteResponse::from)
                         .toList()
         );
     }
@@ -27,6 +33,25 @@ public record RoutieReadResponse(
                     routiePlace.getId(),
                     routiePlace.getSequence(),
                     routiePlace.getPlace().getId()
+            );
+        }
+    }
+
+    private record RouteResponse(
+            int fromSequence,
+            int toSequence,
+            MovingStrategy movingStrategy,
+            int duration,
+            int distance
+    ) {
+
+        private static RouteResponse from(final Route route) {
+            return new RouteResponse(
+                    route.fromSequence(),
+                    route.toSequence(),
+                    route.movingStrategy(),
+                    route.duration(),
+                    route.distance()
             );
         }
     }

--- a/backend/spring-routie/src/main/java/routie/routie/domain/route/RouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/domain/route/RouteCalculator.java
@@ -19,7 +19,7 @@ public class RouteCalculator {
     private final TravelTimeCalculator travelTimeCalculator;
 
     public Map<RoutiePlace, Route> calculateRoutes(final List<RoutiePlace> routiePlaces) {
-        Map<RoutiePlace, Route> routeByFromRoutiePlace = new LinkedHashMap<>();
+        LinkedHashMap<RoutiePlace, Route> routeByFromRoutiePlace = new LinkedHashMap<>();
 
         for (int sequence = 0; sequence < routiePlaces.size() - 1; sequence++) {
             RoutiePlace fromRoutiePlace = routiePlaces.get(sequence);

--- a/backend/spring-routie/src/main/java/routie/routie/service/RoutieService.java
+++ b/backend/spring-routie/src/main/java/routie/routie/service/RoutieService.java
@@ -1,6 +1,7 @@
 package routie.routie.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -38,9 +39,12 @@ public class RoutieService {
     private final RouteCalculator routeCalculator;
     private final ValidityCalculator validityCalculator;
 
-    public RoutieReadResponse getRoutie(final Long id) {
-        return RoutieReadResponse.from(routieRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 id의 루티를 찾을 수 없습니다.")));
+    public RoutieReadResponse getRoutie(final Long routieId) {
+        Routie routie = getRoutieById(routieId);
+        Map<RoutiePlace, Route> routeByFromRoutiePlace = routeCalculator.calculateRoutes(routie.getRoutiePlaces());
+        List<Route> routes = new ArrayList<>(routeByFromRoutiePlace.values());
+
+        return RoutieReadResponse.from(routie, routes);
     }
 
     @Transactional


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
루티 상세 조회 기능이 API 명세와 다름

```yml
{
  "routieId": 123,
  "routiePlaces": [
    {
      "id": 1001,
      "sequence": 1,
      "placeId": 10
    },
    {
      "id": 1002,
      "sequence": 2,
      "placeId": 20
    }
  ]
}
```

## To-Be
<!-- 변경 사항 -->
응답을 아래와 같이 수정
```
{
  "routieId": 123,
  "routiePlaces": [
    {
      "id": 1001,
      "sequence": 1,
      "placeId": 10
    },
    {
      "id": 1002,
      "sequence": 2,
      "placeId": 20
    }
  ],
  "routes": [
      {
          "fromSequence": 1,
          "toSequence": 2,
          "movingStrategy": "DRIVING",
          "duration": 30,
          "distance": 100
      }
  ]
}
```

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

close #214