### PR TITLE
refactor: 루티 스페이스 생성 및 이름 조회/수정 로직 변경

### DIFF
--- a/frontend/src/domains/routieSpace/apis/createRoutieSpace.ts
+++ b/frontend/src/domains/routieSpace/apis/createRoutieSpace.ts
@@ -7,9 +7,12 @@ export const createRoutieSpace = async () => {
     throw new Error('루티 스페이스 생성 실패');
   }
 
-  const uuid = response.headers.get('Location')?.split('/').pop();
+  const data = await response.json();
+  const uuid = data.routieSpaceIdentifier;
 
-  if (!uuid) return;
+  if (!uuid) {
+    throw new Error('루티 스페이스 UUID가 응답에 없습니다.');
+  }
 
   localStorage.setItem('routieSpaceUuid', uuid);
 };

--- a/frontend/src/domains/routieSpace/apis/routieSpaceName.ts
+++ b/frontend/src/domains/routieSpace/apis/routieSpaceName.ts
@@ -7,9 +7,7 @@ export const getRoutieSpaceName = async () => {
     throw new Error('루티 스페이스 uuid가 없습니다.');
   }
 
-  const response = await apiClient.get(
-    `/routie-spaces/${routieSpaceUuid}/name`,
-  );
+  const response = await apiClient.get(`/routie-spaces/${routieSpaceUuid}`);
 
   if (!response.ok) {
     throw new Error('루티 스페이스 이름 조회 실패');
@@ -27,10 +25,9 @@ export const editRoutieSpaceName = async (name: string) => {
     throw new Error('루티 스페이스 uuid가 없습니다.');
   }
 
-  const response = await apiClient.patch(
-    `/routie-spaces/${routieSpaceUuid}/name`,
-    { name },
-  );
+  const response = await apiClient.patch(`/routie-spaces/${routieSpaceUuid}`, {
+    name,
+  });
 
   if (!response.ok) {
     throw new Error('루티 스페이스 이름 수정 실패');


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
루티 스페이스 API에서 name이 제거됨

## To-Be
<!-- 변경 사항 -->
루티 스페이스 생성 및 이름 조회,수정 로직 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
로컬스토리지에 저장할 때는 이전과 같이 `routieSpaceUuid` 이름을 사용함 


<!-- merge 시 이슈를 자동으롷 닫고자 할 때 사용
Closes #{이슈번호}
-->
close #279 