### PR TITLE
refactor: 일정 시작, 종료 시간 입력 제한 추가

### DIFF
--- a/frontend/src/@common/components/Input/Input.tsx
+++ b/frontend/src/@common/components/Input/Input.tsx
@@ -18,6 +18,7 @@ const Input = ({
   onChange,
   variant = 'primary',
   icon,
+  ...props
 }: InputProps) => {
   const iconSrc =
     icon === 'search' ? searchIcon : icon === 'clock' ? clockIcon : null;
@@ -39,6 +40,7 @@ const Input = ({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           disabled={variant === 'disabled'}
+          {...props}
         />
       </div>
     </>

--- a/frontend/src/@common/utils/format.ts
+++ b/frontend/src/@common/utils/format.ts
@@ -1,0 +1,9 @@
+export const getKoreanDateTimeISO = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+};

--- a/frontend/src/domains/routie/contexts/useRoutieValidateContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieValidateContext.tsx
@@ -2,12 +2,14 @@ import { createContext, useMemo, useContext } from 'react';
 
 import useRoutieValidate, {
   UseRoutieValidateReturn,
-  initialTime,
 } from '../hooks/useRoutieValidate';
 
 const RoutieValidateContext = createContext<UseRoutieValidateReturn>({
   isValidateActive: false,
-  routieTime: initialTime,
+  routieTime: {
+    startDateTime: '',
+    endDateTime: '',
+  },
   isValidateRoutie: false,
   handleValidateToggle: () => {},
   handleTimeChange: () => {},

--- a/frontend/src/domains/routie/hooks/useRoutieValidate.ts
+++ b/frontend/src/domains/routie/hooks/useRoutieValidate.ts
@@ -61,6 +61,9 @@ const useRoutieValidate = (): UseRoutieValidateReturn => {
   }, [isValidateActive, routieTime]);
 
   useEffect(() => {
+    if (routieTime.startDateTime === '' || routieTime.endDateTime === '')
+      return;
+
     validateRoutie();
   }, [validateRoutie]);
 

--- a/frontend/src/domains/routie/hooks/useRoutieValidate.ts
+++ b/frontend/src/domains/routie/hooks/useRoutieValidate.ts
@@ -2,17 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { getRoutieValidation } from '../apis/routie';
 
-const getTomorrowDate = () => {
-  const tomorrow = new Date();
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  return tomorrow.toISOString().split('T')[0];
-};
-
-export const initialTime = {
-  startDateTime: `${getTomorrowDate()}T10:00`,
-  endDateTime: `${getTomorrowDate()}T11:00`,
-};
-
 export interface UseRoutieValidateReturn {
   isValidateActive: boolean;
   routieTime: {
@@ -37,7 +26,10 @@ const useRoutieValidate = (): UseRoutieValidateReturn => {
   const [isValidateActive, setIsValidateActive] = useState(
     getInitialValidateActive,
   );
-  const [routieTime, setRoutieTime] = useState(initialTime);
+  const [routieTime, setRoutieTime] = useState({
+    startDateTime: '',
+    endDateTime: '',
+  });
   const [isValidateRoutie, setIsValidateRoutie] = useState(false);
 
   const handleValidateToggle = useCallback(() => {

--- a/frontend/src/layouts/Sidebar/TimeInput.tsx
+++ b/frontend/src/layouts/Sidebar/TimeInput.tsx
@@ -1,5 +1,6 @@
 import Flex from '@/@common/components/Flex/Flex';
 import Input from '@/@common/components/Input/Input';
+import { getKoreanDateTimeISO } from '@/@common/utils/format';
 
 const TimeInput = ({
   time,
@@ -8,6 +9,8 @@ const TimeInput = ({
   time: { startDateTime: string; endDateTime: string };
   onChange: (field: 'startDateTime' | 'endDateTime', value: string) => void;
 }) => {
+  const minimumStartDateTime = getKoreanDateTimeISO(new Date());
+
   return (
     <Flex justifyContent="space-between" width="100%" gap={1}>
       <Flex direction="column" alignItems="flex-start" gap={1} width="100%">
@@ -16,15 +19,19 @@ const TimeInput = ({
           label="시작"
           type="datetime-local"
           value={time.startDateTime}
+          min={minimumStartDateTime}
           onChange={(value) => onChange('startDateTime', value)}
         />
       </Flex>
       <Flex direction="column" alignItems="flex-start" gap={1} width="100%">
         <Input
+          disabled={time.startDateTime === ''}
           id="endAt"
           label="종료"
           type="datetime-local"
           value={time.endDateTime}
+          min={time.startDateTime ? time.startDateTime : minimumStartDateTime}
+          max={time.startDateTime ? time.startDateTime : minimumStartDateTime}
           onChange={(value) => onChange('endDateTime', value)}
         />
       </Flex>


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 일정 시간을 선택할 때 현재 시간 이전의 날짜도 선택할 수 있는 문제를 발견
- 종료 시간의 경우 하루의 일정을 계획하는 서비스의 목표와 달리 제한 없는 날짜 선택이 가능했던 문제를 발견
- 사용자가 아직 날짜를 선택하지 않았는데 검증 기능을 활성화 하면 바로 검증 요청이 가는 문제를 발견

## To-Be
<!-- 변경 사항 -->
- 시작 날짜는 현재 시간 기준으로 이전 날짜를 선택할 수 없게 수정
- 종료 시간은 날짜는 시작 날짜와 다르게 적용할 수 없고 시간만 변경할 수 있게 수정
- 아직 날짜를 선택하지 않은 경우 검증 요청을 보내지 않게 수정
- 종료 시간은 시작 시간을 입력하기 전에 입력할 수 없게 제한


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/6b362c4d-621b-44fb-90d9-4ce7e33c64bc



## (Optional) Additional Description
1. Input 컴포넌트에서 input tag 내장 속성을 사용할 수 없는 문제를 수정했습니다
2. 이후에 루티에 장소가 없는 경우에도 검증 요청을 보내지 않게 수정할 계획입니다


Closes #284 
