### PR TITLE
refactor: 루티 관련 상태를 context로 분리

### DIFF
--- a/frontend/src/domains/routie/components/RoutiePlaceCard/RoutiePlaceCard.tsx
+++ b/frontend/src/domains/routie/components/RoutiePlaceCard/RoutiePlaceCard.tsx
@@ -10,18 +10,18 @@ import trashIcon from '@/assets/icons/trash.svg';
 import theme from '@/styles/theme';
 
 import { getDetailPlace } from '../../apis/routie';
+import { useRoutieContext } from '../../contexts/useRoutieContext';
 import { RoutiePlace } from '../../types/routie.types';
 
 const RoutiePlaceCard = ({
   placeId,
-  handleDelete,
   onPlaceChange,
 }: {
   placeId: number;
-  handleDelete: () => void;
   onPlaceChange?: () => Promise<void>;
 }) => {
   const [place, setPlace] = useState<RoutiePlace>();
+  const { handleRoutieDelete } = useRoutieContext();
 
   useEffect(() => {
     const fetchDetailPlace = async () => {
@@ -51,7 +51,7 @@ const RoutiePlaceCard = ({
                 <IconButton
                   icon={trashIcon}
                   variant="delete"
-                  onClick={handleDelete}
+                  onClick={() => handleRoutieDelete(placeId)}
                 />
               </Flex>
             </Flex>

--- a/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
+++ b/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
@@ -1,0 +1,83 @@
+import { useEffect } from 'react';
+
+import Flex from '@/@common/components/Flex/Flex';
+import Pill from '@/@common/components/Pill/Pill';
+import Text from '@/@common/components/Text/Text';
+import theme from '@/styles/theme';
+
+import { editRoutieSequence } from '../../apis/routie';
+import { MOVING_EN_TO_KR } from '../../constants/translate';
+import { useRoutieContext } from '../../contexts/useRoutieContext';
+import { useRoutieValidateContext } from '../../contexts/useRoutieValidateContext';
+import { useCardDrag } from '../../hooks/useCardDrag';
+import { Routie } from '../../types/routie.types';
+import { convertMetersToKilometers } from '../../utils/format';
+import RoutiePlaceCard from '../RoutiePlaceCard/RoutiePlaceCard';
+
+interface RoutieSectionProps {
+  onPlaceChange: () => Promise<void>;
+}
+
+const RoutieSection = ({ onPlaceChange }: RoutieSectionProps) => {
+  const { routiePlaces, routes, setRoutiePlaces } = useRoutieContext();
+  const getDragProps = useCardDrag(routiePlaces, setRoutiePlaces);
+  const { validateRoutie } = useRoutieValidateContext();
+
+  useEffect(() => {
+    if (!routiePlaces) return;
+
+    const updated = routiePlaces.map((item, index) => ({
+      ...item,
+      sequence: index + 1,
+    }));
+
+    const isSequenceChanged = routiePlaces.some(
+      (item, index) => item.sequence !== index + 1,
+    );
+
+    const updateRoutiePlaces = async (sortedPlaces: Routie[]) => {
+      setRoutiePlaces(sortedPlaces);
+      await editRoutieSequence(sortedPlaces);
+      await validateRoutie();
+    };
+
+    if (isSequenceChanged) {
+      const sortedPlaces = updated.sort((a, b) => a.sequence - b.sequence);
+      updateRoutiePlaces(sortedPlaces);
+    }
+  }, [routiePlaces]);
+
+  const handleDelete = (id: number) => {
+    const next = routiePlaces.filter((item) => item.placeId !== id);
+    editRoutieSequence(next);
+    setRoutiePlaces(next);
+  };
+
+  return routiePlaces.map((place, index) => (
+    <>
+      <div key={place.placeId} {...getDragProps(index)}>
+        <RoutiePlaceCard
+          placeId={place.placeId}
+          handleDelete={() => handleDelete(place.placeId)}
+          onPlaceChange={onPlaceChange}
+        />
+      </div>
+
+      {routiePlaces.length - 1 !== index && routes && (
+        <Flex key={place.id + index} gap={1}>
+          <Text variant="description">
+            {MOVING_EN_TO_KR[routes[index].movingStrategy]}{' '}
+            {routes[index].duration}분
+          </Text>
+          <Pill type="distance">
+            <Text variant="description" color={theme.colors.purple[400]}>
+              {convertMetersToKilometers(routes[index].distance)}km
+            </Text>
+          </Pill>
+        </Flex>
+      )}
+    </>
+  ));
+};
+
+export default RoutieSection;

--- a/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
+++ b/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
@@ -63,7 +63,7 @@ const RoutieSection = ({ onPlaceChange }: RoutieSectionProps) => {
         />
       </div>
 
-      {routiePlaces.length - 1 !== index && routes && (
+      {routiePlaces.length - 1 !== index && routes[index] && routes && (
         <Flex key={place.id + index} gap={1}>
           <Text variant="description">
             {MOVING_EN_TO_KR[routes[index].movingStrategy]}{' '}

--- a/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
+++ b/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
@@ -19,10 +19,9 @@ interface RoutieSectionProps {
 }
 
 const RoutieSection = ({ onPlaceChange }: RoutieSectionProps) => {
-  const { routiePlaces, routes, setRoutiePlaces } = useRoutieContext();
-  const getDragProps = useCardDrag(routiePlaces, setRoutiePlaces);
+  const { routiePlaces, routes, handleRoutieChange } = useRoutieContext();
+  const getDragProps = useCardDrag(routiePlaces, handleRoutieChange);
   const { validateRoutie } = useRoutieValidateContext();
-
   useEffect(() => {
     if (!routiePlaces) return;
 
@@ -36,7 +35,7 @@ const RoutieSection = ({ onPlaceChange }: RoutieSectionProps) => {
     );
 
     const updateRoutiePlaces = async (sortedPlaces: Routie[]) => {
-      setRoutiePlaces(sortedPlaces);
+      handleRoutieChange(sortedPlaces);
       await editRoutieSequence(sortedPlaces);
       await validateRoutie();
     };
@@ -47,18 +46,11 @@ const RoutieSection = ({ onPlaceChange }: RoutieSectionProps) => {
     }
   }, [routiePlaces]);
 
-  const handleDelete = (id: number) => {
-    const next = routiePlaces.filter((item) => item.placeId !== id);
-    editRoutieSequence(next);
-    setRoutiePlaces(next);
-  };
-
   return routiePlaces.map((place, index) => (
     <>
       <div key={place.placeId} {...getDragProps(index)}>
         <RoutiePlaceCard
           placeId={place.placeId}
-          handleDelete={() => handleDelete(place.placeId)}
           onPlaceChange={onPlaceChange}
         />
       </div>

--- a/frontend/src/domains/routie/constants/translate.ts
+++ b/frontend/src/domains/routie/constants/translate.ts
@@ -1,0 +1,3 @@
+export const MOVING_EN_TO_KR = {
+  DRIVING: '운전',
+};

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -1,0 +1,69 @@
+import {
+  createContext,
+  useMemo,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+} from 'react';
+
+import { getRoutieId } from '../apis/routie';
+import { Routes, Routie } from '../types/routie.types';
+
+type RoutieContextType = {
+  routiePlaces: Routie[];
+  setRoutiePlaces: React.Dispatch<React.SetStateAction<Routie[]>>;
+  routes: Routes[];
+  refetchRoutieData: () => Promise<void>;
+};
+
+const RoutieContext = createContext<RoutieContextType>({
+  routiePlaces: [],
+  setRoutiePlaces: () => {},
+  routes: [],
+  refetchRoutieData: async () => {},
+});
+
+export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
+  const [routiePlaces, setRoutiePlaces] = useState<Routie[] | []>([]);
+  const [routes, setRoutes] = useState<Routes[] | []>([]);
+
+  const refetchRoutieData = useCallback(async () => {
+    try {
+      const routies = await getRoutieId();
+      setRoutiePlaces(routies.routiePlaces);
+      setRoutes(routies.routes);
+    } catch (error) {
+      console.error('루티 정보를 불러오는데 실패했습니다.', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    refetchRoutieData();
+  }, []);
+
+  const contextValue = useMemo(() => {
+    return {
+      routiePlaces,
+      setRoutiePlaces,
+      routes,
+      refetchRoutieData,
+    };
+  }, [routiePlaces, setRoutiePlaces, routes, refetchRoutieData]);
+
+  return (
+    <RoutieContext.Provider value={contextValue}>
+      {children}
+    </RoutieContext.Provider>
+  );
+};
+
+export const useRoutieContext = () => {
+  const context = useContext(RoutieContext);
+
+  if (!context) {
+    throw new Error('useRoutieContext must be used within a RoutieProvider');
+  }
+
+  return context;
+};

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -29,8 +29,8 @@ const RoutieContext = createContext<RoutieContextType>({
 });
 
 export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
-  const [routiePlaces, setRoutiePlaces] = useState<Routie[] | []>([]);
-  const [routes, setRoutes] = useState<Routes[] | []>([]);
+  const [routiePlaces, setRoutiePlaces] = useState<Routie[]>([]);
+  const [routes, setRoutes] = useState<Routes[]>([]);
   const routieIdList = useMemo(
     () => routiePlaces.map((routie) => routie.placeId),
     [routiePlaces],

--- a/frontend/src/domains/routie/utils/format.ts
+++ b/frontend/src/domains/routie/utils/format.ts
@@ -1,0 +1,3 @@
+export const convertMetersToKilometers = (distance: number) => {
+  return (distance / 1000).toFixed(1);
+};

--- a/frontend/src/layouts/PlaceList/PlaceList.tsx
+++ b/frontend/src/layouts/PlaceList/PlaceList.tsx
@@ -1,33 +1,12 @@
 import Flex from '@/@common/components/Flex/Flex';
 import Text from '@/@common/components/Text/Text';
 import { PlaceCard } from '@/domains/places/components/PlaceCard/PlaceCard';
-import { Routie } from '@/domains/routie/types/routie.types';
 
 import gridContainerStyle from './PlaceList.styles';
 import { usePlaceListContext } from './contexts/PlaceListContext';
-import { usePlaceList } from './hooks/usePlaceList';
 
-interface PlaceListProps {
-  routiePlaces: Routie[];
-  setRoutiePlaces: React.Dispatch<React.SetStateAction<Routie[] | undefined>>;
-  onRoutieDataChange?: () => Promise<void>;
-}
-
-const PlaceList = ({
-  routiePlaces,
-  setRoutiePlaces,
-  onRoutieDataChange,
-}: Omit<PlaceListProps, 'places'>) => {
+const PlaceList = () => {
   const { placeList, refetchPlaceList, handleDelete } = usePlaceListContext();
-
-  const placeCardList = usePlaceList({
-    places: placeList,
-    onDelete: handleDelete,
-    onPlaceChange: refetchPlaceList,
-    routiePlaces,
-    setRoutiePlaces,
-    onRoutieDataChange,
-  });
 
   return (
     <Flex
@@ -41,7 +20,7 @@ const PlaceList = ({
     >
       <Text variant="title">장소 목록</Text>
       <div css={gridContainerStyle}>
-        {placeCardList.map(({ id, onSelect, selected, ...rest }) => (
+        {placeList.map(({ id, onSelect, selected, ...rest }) => (
           <PlaceCard
             id={id}
             key={id}

--- a/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -110,7 +110,7 @@ const Sidebar = () => {
               boxSizing: 'border-box',
             }}
           >
-            <RoutieSection />
+            <RoutieSection onPlaceChange={refetchPlaceList} />
           </Flex>
         </Flex>
       </Flex>

--- a/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
+++ b/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
@@ -1,61 +1,19 @@
-import { useEffect, useState } from 'react';
-
 import Flex from '@/@common/components/Flex/Flex';
-import { getRoutieId } from '@/domains/routie/apis/routie';
 import { RoutieValidateProvider } from '@/domains/routie/contexts/useRoutieValidateContext';
-import { Routes, Routie } from '@/domains/routie/types/routie.types';
 import PlaceList from '@/layouts/PlaceList/PlaceList';
 import { PlaceListProvider } from '@/layouts/PlaceList/contexts/PlaceListProvider';
 import Sidebar from '@/layouts/Sidebar/Sidebar';
 
 const RoutieSpace = () => {
-  const [routiePlaces, setRoutiePlaces] = useState<Routie[] | undefined>();
-  const [routes, setRoutes] = useState<Routes[] | undefined>();
-
-  const refetchRoutieData = async () => {
-    try {
-      const routies = await getRoutieId();
-      setRoutiePlaces(routies.routiePlaces);
-      setRoutes(routies.routes);
-    } catch (error) {
-      console.error('루티 정보를 불러오는데 실패했습니다.', error);
-    }
-  };
-
-  useEffect(() => {
-    const fetchRoutieId = async () => {
-      try {
-        const routies = await getRoutieId();
-
-        setRoutiePlaces(routies.routiePlaces);
-        setRoutes(routies.routes);
-      } catch (error) {
-        console.error('Failed to get routieId:', error);
-      }
-    };
-
-    fetchRoutieId();
-  }, []);
-
   return (
     <RoutieValidateProvider>
       <PlaceListProvider>
         <Flex justifyContent="flex-start" height="100vh">
           <Flex direction="column" justifyContent="flex-start" height="100%">
-            {
-              <Sidebar
-                routiePlaces={routiePlaces ?? []}
-                setRoutiePlaces={setRoutiePlaces}
-                routes={routes}
-              />
-            }
+            <Sidebar />
           </Flex>
           <Flex direction="column" justifyContent="flex-start" height="100%">
-            <PlaceList
-              routiePlaces={routiePlaces ?? []}
-              setRoutiePlaces={setRoutiePlaces}
-              onRoutieDataChange={refetchRoutieData}
-            />
+            <PlaceList />
           </Flex>
         </Flex>
       </PlaceListProvider>


### PR DESCRIPTION
## As-Is
루티 관련 상태들이 RoutieSpace 페이지부터 하위 컴포넌트로 props drilling 발생.

## To-Be
- 브라우저 화면상 루티 레이아웃 부분을 컴포넌트로 분리
- 루티 컴포넌트에서 사용하는 상수 파일로 분리
- 루티 관련 상태 context에 구현

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="961" height="718" alt="image" src="https://github.com/user-attachments/assets/888bffee-4c42-4917-b0db-9bb4d329db31" />


## (Optional) Additional Description

Closes #287

