### PR TITLE
refactor: 이름 수정 버튼을 눌렀을 때 유저가 수정 중인 것을 확실하게 인지할 수 있게 수정

### DIFF
--- a/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.style.ts
+++ b/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.style.ts
@@ -3,17 +3,17 @@ import { css } from '@emotion/react';
 import theme from '@/styles/theme';
 
 const routieSpaceNameInputStyle = css`
-  width: auto;
+  width: 100%;
   margin: 0;
-  padding: 0;
+  padding: 0.4rem;
   border: none;
 
   font-size: ${theme.font.size.heading};
   font-weight: ${theme.font.weight.bold};
-  color: ${theme.colors.purple[300]};
 
   &:focus {
-    outline: none;
+    border-radius: 8px;
+    outline: 0.3rem solid ${theme.colors.purple[300]};
   }
 `;
 

--- a/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.tsx
+++ b/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.tsx
@@ -43,7 +43,13 @@ const RoutieSpaceName = () => {
   };
 
   return (
-    <Flex alignItems="center" justifyContent="space-between" width="100%">
+    <Flex
+      alignItems="center"
+      justifyContent="space-between"
+      width="100%"
+      margin={0.4}
+      gap={3}
+    >
       {isEditing ? (
         <input
           id="routie-space-name"
@@ -54,7 +60,14 @@ const RoutieSpaceName = () => {
           onChange={handleChange}
         />
       ) : (
-        <Text variant="title">{name}</Text>
+        <Flex
+          alignItems="center"
+          justifyContent="flex-start"
+          padding={0.4}
+          width="100%"
+        >
+          <Text variant="title">{name}</Text>
+        </Flex>
       )}
       <IconButton icon={editIcon} onClick={handleClick} />
     </Flex>


### PR DESCRIPTION
Input의 outline 적용

## As-Is
<!-- 문제 상황 정의 -->
- 유저가 수정 모드인 것을 인지하기 어려운 문제를 발견

## To-Be
<!-- 변경 사항 -->
- 유저가 이름을 수정할 때 수정 모드인 것을 바로 인지할 수 있는 UI를 적용


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

<img width="482" height="64" alt="image" src="https://github.com/user-attachments/assets/8f9be02e-ede9-4842-aa91-4ee92701f28e" />


## (Optional) Additional Description



Closes #331 

