### PR TITLE
chore: 장소 카드 휴무일 리스트를 space-around를 통해 자동 gap으로 수정

### DIFF
--- a/frontend/src/domains/places/components/DatePreviewList/DatePreviewList.tsx
+++ b/frontend/src/domains/places/components/DatePreviewList/DatePreviewList.tsx
@@ -10,7 +10,7 @@ interface DatePreviewListProps {
 
 const DatePreviewList = ({ value }: DatePreviewListProps) => {
   return (
-    <Flex gap={0.7}>
+    <Flex justifyContent="space-around" width="100%">
       {DAY_KR_LIST.map((day, index) => (
         <DatePreviewItem
           key={day}


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 장소 카드의 휴무일 리스트의 스타일이 깨지는 문제가 있었음
- gap이 지정이 되어있어서 원이 아니였음

## To-Be
<!-- 변경 사항 -->
- Flex 컴포넌트의 props를  `justifyContent="space-around" width="100%"`로 지정해 내부 요소의 크기에 맞춰 gap이 적용 되도록 함

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
|변경 전|변경 후|
|---|---|
|<img width="330" height="151" alt="image" src="https://github.com/user-attachments/assets/4aeb477a-c2a3-491b-bb53-55fcba2d6e1b" />|<img width="342" height="181" alt="image" src="https://github.com/user-attachments/assets/5028c111-f0af-4272-9c8c-0ceb2a2cbec4" />|


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으롷 닫고자 할 때 사용
Closes #{이슈번호}
-->
close #343 