### PR TITLE
feat: 전체 일정 시작시간 입력시 장소별 일정 도착, 출발 시간을 UI에 표시

### DIFF
--- a/frontend/src/domains/routie/apis/routie.ts
+++ b/frontend/src/domains/routie/apis/routie.ts
@@ -2,15 +2,21 @@ import { apiClient } from '@/apis';
 
 import { Routie } from '../types/routie.types';
 
-export const getRoutie = async () => {
+export const getRoutie = async (
+  isValidateActive: boolean,
+  routieTime: string,
+) => {
   const routieSpaceUuid = localStorage.getItem('routieSpaceUuid');
 
   if (!routieSpaceUuid) {
     throw new Error('루티 스페이스 uuid가 없습니다.');
   }
 
+  const query =
+    isValidateActive && routieTime ? `?startDateTime=${routieTime}` : '';
+
   const response = await apiClient.get(
-    `/routie-spaces/${routieSpaceUuid}/routie`,
+    `/routie-spaces/${routieSpaceUuid}/routie${query}`,
   );
 
   if (!response.ok) {

--- a/frontend/src/domains/routie/components/RoutiePlaceCard/RoutiePlaceCard.tsx
+++ b/frontend/src/domains/routie/components/RoutiePlaceCard/RoutiePlaceCard.tsx
@@ -7,27 +7,30 @@ import Pill from '@/@common/components/Pill/Pill';
 import Text from '@/@common/components/Text/Text';
 import dragIcon from '@/assets/icons/drag.svg';
 import trashIcon from '@/assets/icons/trash.svg';
-import theme from '@/styles/theme';
 
 import { getDetailPlace } from '../../apis/routie';
 import { useRoutieContext } from '../../contexts/useRoutieContext';
-import { RoutiePlace } from '../../types/routie.types';
+import { Routie, RoutiePlace } from '../../types/routie.types';
 
-const RoutiePlaceCard = ({ placeId }: { placeId: number }) => {
+const RoutiePlaceCard = ({ routie }: { routie: Routie }) => {
   const [place, setPlace] = useState<RoutiePlace>();
   const { handleDeleteRoutie } = useRoutieContext();
 
   useEffect(() => {
     const fetchDetailPlace = async () => {
-      const detailPlace = await getDetailPlace(placeId);
+      const detailPlace = await getDetailPlace(routie.placeId);
       setPlace(detailPlace);
     };
     fetchDetailPlace();
-  }, [placeId]);
+  }, [routie.placeId]);
 
   return (
     place && (
-      <Card id={placeId.toString()} width="45rem" variant="defaultStatic">
+      <Card
+        id={routie.placeId.toString()}
+        width="45rem"
+        variant="defaultStatic"
+      >
         <Flex justifyContent="flex-start" gap={1.5}>
           <IconButton variant="drag" icon={dragIcon} onClick={() => {}} />
           <Flex
@@ -39,21 +42,17 @@ const RoutiePlaceCard = ({ placeId }: { placeId: number }) => {
             <Flex width="100%" justifyContent="space-between">
               <Text variant="caption">{place.name}</Text>
               <Flex gap={0.4}>
-                <Pill variant="filled" type="time">
-                  {place.stayDurationMinutes}분
-                </Pill>
                 <IconButton
                   icon={trashIcon}
                   variant="delete"
-                  onClick={() => handleDeleteRoutie(placeId)}
+                  onClick={() => handleDeleteRoutie(routie.placeId)}
                 />
               </Flex>
             </Flex>
-            <Text variant="label" color={theme.colors.gray[200]}>
-              {place.address}
-            </Text>
             <Pill type="time">
-              {place.openAt}-{place.closeAt}
+              {routie.arriveDateTime?.slice(-5)}-
+              {routie.departureDateTime?.slice(-5)}{' '}
+              <Pill type="distance">{place.stayDurationMinutes}분</Pill>
             </Pill>
           </Flex>
         </Flex>

--- a/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
+++ b/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
@@ -30,7 +30,7 @@ const RoutieSection = () => {
   return routiePlaces.map((place, index) => (
     <div key={place.placeId}>
       <div {...getDragProps(index)}>
-        <RoutiePlaceCard placeId={place.placeId} />
+        <RoutiePlaceCard routie={place} />
       </div>
 
       {routiePlaces.length - 1 !== index && routes[index] && (

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -14,6 +14,8 @@ import {
 } from '../apis/routie';
 import { Routes, Routie } from '../types/routie.types';
 
+import { useRoutieValidateContext } from './useRoutieValidateContext';
+
 type RoutieContextType = {
   routiePlaces: Routie[];
   routes: Routes[];
@@ -38,16 +40,20 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
   const [routiePlaces, setRoutiePlaces] = useState<Routie[]>([]);
   const [routes, setRoutes] = useState<Routes[]>([]);
   const routieIdList = routiePlaces.map((routie) => routie.placeId);
+  const { isValidateActive, routieTime } = useRoutieValidateContext();
 
   const refetchRoutieData = useCallback(async () => {
     try {
-      const routies = await getRoutie();
+      const routies = await getRoutie(
+        isValidateActive,
+        routieTime.startDateTime,
+      );
       setRoutiePlaces(routies.routiePlaces);
       setRoutes(routies.routes);
     } catch (error) {
       console.error('루티 정보를 불러오는데 실패했습니다.', error);
     }
-  }, []);
+  }, [isValidateActive, routieTime.startDateTime]);
 
   const handleAddRoutie = useCallback(
     async (id: number) => {
@@ -83,6 +89,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
       try {
         await editRoutieSequence(sortedList);
         setRoutiePlaces(sortedList);
+        refetchRoutieData();
       } catch (error) {
         console.error(error);
       }
@@ -92,7 +99,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
 
   useEffect(() => {
     refetchRoutieData();
-  }, []);
+  }, [isValidateActive, routieTime.startDateTime, refetchRoutieData]);
 
   return (
     <RoutieContext.Provider


### PR DESCRIPTION
## As-Is
- 루티 장소에 불필요한 오픈 / 마감 시간과 장소명 대신에 필요한 정보 표시

## To-Be
- 루티 장소에 불필요한 오픈 / 마감 시간과 장소명 제거
- 루티에 장소에 각 일정별 출발 시간 / 도착 시간을 표시


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
https://github.com/user-attachments/assets/811904bb-e386-497d-be45-3f25b62bd468

## (Optional) Additional Description

Closes #337

