### PR TITLE
fix: 루티에서 장소 검증 동작 오류로 개선

### DIFF
--- a/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
+++ b/frontend/src/domains/routie/components/RoutieSection/RoutieSection.tsx
@@ -15,12 +15,6 @@ const RoutieSection = () => {
     if (!routiePlaces) return;
     if (routiePlaces.length <= 0) return;
 
-    const isSequenceChanged = routiePlaces.some(
-      (item, index) => item.sequence !== index + 1,
-    );
-
-    if (!isSequenceChanged) return;
-
     const updateRoutiePlaces = async () => {
       await validateRoutie();
     };

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -89,7 +89,6 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
       try {
         await editRoutieSequence(sortedList);
         setRoutiePlaces(sortedList);
-        refetchRoutieData();
       } catch (error) {
         console.error(error);
       }


### PR DESCRIPTION
## As-Is
- 루티 장소 추가 / 삭제 / 수정 시 검증 로직이 제대로 동작하지 않음.
- 루티 검증 API 를 2번씩 호출

## To-Be
- useEffect 내부 불필요한 로직 제거
- 루티 장소 변경 시 불필요한 fetch 로직 제거


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
https://github.com/user-attachments/assets/2f87d374-4066-424c-bc41-6bca68475231


## (Optional) Additional Description

Closes #360 
