### PR TITLE
refactor: 선택된 아이콘 버튼의 포인터 이벤트 비활성화

### DIFF
--- a/frontend/src/@common/components/IconButton/IconButton.style.ts
+++ b/frontend/src/@common/components/IconButton/IconButton.style.ts
@@ -30,6 +30,8 @@ const iconButtonVariant: Record<IconButtonVariantProps, SerializedStyles> = {
   `,
 
   selected: css`
+    pointer-events: none;
+
     width: 3rem;
     height: 3rem;
     padding: 0.4rem;

--- a/frontend/src/domains/places/components/PlaceCard/PlaceCard.tsx
+++ b/frontend/src/domains/places/components/PlaceCard/PlaceCard.tsx
@@ -30,6 +30,8 @@ export const PlaceCard = ({ selected, ...props }: PlaceCardProps) => {
   const { triggerEvent } = useGoogleEventTrigger();
 
   const handlePlaceSelect = async () => {
+    if (selected) return;
+
     try {
       await handleAddRoutie(props.id);
       triggerEvent({


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
- 루티 장소는 장소 목록 카드에서 삭제가 되는 사용자의 혼란이 있었습니다.
- 따라서 루티 장소에 들어가있는 장소 목록 카드에서는 선택되었을 경우 버튼을 비활성화 혼란을 줄였습니다. 


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/05ce82d1-058d-4534-80da-00226fe95628


## (Optional) Additional Description


Closes #381 
