### PR TITLE
refactor: 루티에 장소가 하나만 있는 경우에 요청을 보내지 않게 수정

### DIFF
--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -16,6 +16,7 @@ import { Routes, Routie } from '../types/routie.types';
 
 import { useRoutieValidateContext } from './useRoutieValidateContext';
 
+
 type RoutieContextType = {
   routiePlaces: Routie[];
   routes: Routes[];
@@ -40,7 +41,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
   const [routiePlaces, setRoutiePlaces] = useState<Routie[]>([]);
   const [routes, setRoutes] = useState<Routes[]>([]);
   const routieIdList = routiePlaces.map((routie) => routie.placeId);
-  const { isValidateActive, routieTime } = useRoutieValidateContext();
+  const { isValidateActive, routieTime, validateRoutie } = useRoutieValidateContext();
 
   const refetchRoutieData = useCallback(async () => {
     try {
@@ -89,16 +90,25 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
       try {
         await editRoutieSequence(sortedList);
         setRoutiePlaces(sortedList);
+        validateRoutie(sortedList.length);
       } catch (error) {
         console.error(error);
       }
     },
-    [routiePlaces],
+    [validateRoutie],
   );
 
   useEffect(() => {
     refetchRoutieData();
   }, [isValidateActive, routieTime.startDateTime, refetchRoutieData]);
+
+  useEffect(() => {
+    validateRoutie(routiePlaces.length);
+  }, [routiePlaces.length, validateRoutie]);
+
+  useEffect(() => {
+    validateRoutie(routiePlaces.length);
+  }, [routieTime.startDateTime, routieTime.endDateTime, validateRoutie, routiePlaces.length]);
 
   return (
     <RoutieContext.Provider


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
검증 요청 api가 변경되면서 루티에 장소가 하나만 있는 경우에 결과를 무조건 `true`로 반환하는 문제를 발견,
그에 맞게 루티에 장소가 하나만 있는 경우에는 검증 요청을 보내지 않는 방식으로 로직을 수정한다

## To-Be
<!-- 변경 사항 -->
- `useRoutieValidate` 훅에서 검증 요청 함수를 직접 호출하지 않는다
- 실제 요청을 보낼지 말지는 `useRoutieValidate` 훅에서 판단하지만 실질적으로 함수를 호출하는 것은 외부에 위임한다
- `useRoutieContext`에서 `validateRoutie` 함수를 호출한다
- `validateRoutie`를 호출할 때는 `routie`의 길이를 인자로 전달한다

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

api가 수정되기 전에는 장소가 하나만 있어도 검증이 가능했는데 수정 이후에는 루티에 장소가 하나만 있는 경우 검증 결과가 올바르지 않는 것을 발견했습니다. 그렇기 때문에 루티에 장소가 하나만 있는 경우에는 검증 요청을 보내지 않는 방식으로 로직을 수정했습니다.

검증 요청에 루티 길이가 필요해졌기 때문에 `useRoutieValidate` 훅에서 `useEffect`로 자동 검증을 갱신하는 것이 불가능해져(**루티 길이를 검증 훅으로 불러오는 것은 순환 참조 문제가 있음**) `validateRoutie`가 인자로 루티의 길이를 받을 수 있게 수정했고 데이터 변경에 따라 자동으로 검증을 갱신하는 로직을 `useRoutieContext`로 위임했습니다.

만약 더 좋은 아이디어가 있다면 의견 남겨주시면 감사하겠습니다 🙇

추가로 검증 기능이 활성화 되어 있지만 요청을 보내지 않은 상태에 맞는 메시지를 보여주는 수정은 해당 pr이 머지되면 작업하겠습니다 🙂



Closes #390 

