### PR TITLE
refactor: 장소 검색 API 변수명 리팩터링

### DIFF
--- a/backend/spring-routie/src/main/java/routie/place/controller/dto/response/SearchedPlacesResponse.java
+++ b/backend/spring-routie/src/main/java/routie/place/controller/dto/response/SearchedPlacesResponse.java
@@ -16,7 +16,7 @@ public record SearchedPlacesResponse(
     }
 
     public record SearchedPlaceResponse(
-            String id,
+            String searchedPlaceId,
             String name,
             String roadAddressName,
             Double longitude,
@@ -25,7 +25,7 @@ public record SearchedPlacesResponse(
 
         public static SearchedPlaceResponse from(final SearchedPlace searchedPlace) {
             return new SearchedPlaceResponse(
-                    searchedPlace.id(),
+                    searchedPlace.searchedPlaceId(),
                     searchedPlace.name(),
                     searchedPlace.roadAddressName(),
                     searchedPlace.longitude(),

--- a/backend/spring-routie/src/main/java/routie/place/domain/SearchedPlace.java
+++ b/backend/spring-routie/src/main/java/routie/place/domain/SearchedPlace.java
@@ -1,7 +1,7 @@
 package routie.place.domain;
 
 public record SearchedPlace(
-        String id,
+        String searchedPlaceId,
         String name,
         String roadAddressName,
         Double longitude,

--- a/backend/spring-routie/src/test/java/routie/place/domain/PlaceSearcherTest.java
+++ b/backend/spring-routie/src/test/java/routie/place/domain/PlaceSearcherTest.java
@@ -19,7 +19,7 @@ class PlaceSearcherTest {
         List<SearchedPlace> searchedPlaces = placeSearcher.search(query);
         for (final SearchedPlace searchedPlace : searchedPlaces) {
             System.out.println(
-                    searchedPlace.id() + ", "
+                    searchedPlace.searchedPlaceId() + ", "
                             + searchedPlace.name() + ", "
                             + searchedPlace.roadAddressName() + ", "
                             + searchedPlace.latitude() + ", "


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
검색된 장소의 id와 DB에 저장된 장소의 id의 변수명이 같아 프론트에서 혼란을 겪음

## To-Be
<!-- 변경 사항 -->
- 검색된 장소의 id: `searchedPlaceId`
- DB에 저장된 장소의 id: `id`(현행 유지)

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
