### PR TITLE
fix: 루티 장소 순서 변경 시 refetch 하도록 수정

### DIFF
--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -90,8 +90,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
         .sort((a, b) => a.sequence - b.sequence);
       try {
         await editRoutieSequence(sortedList);
-        setRoutiePlaces(sortedList);
-        validateRoutie(sortedList.length);
+        refetchRoutieData();
       } catch (error) {
         console.error(error);
       }


### PR DESCRIPTION
## As-Is
- 루티에서 장소 순서 변경 시 시간과 거리가 변경되지 않음.


## To-Be
- 루티에서 장소 순서 변경 시 refetch 하도록 개선


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


https://github.com/user-attachments/assets/e356b81d-a7cc-40ef-90b7-b4c33428f43e


## (Optional) Additional Description

Closes #433 
