### PR TITLE
refactor: text 컴포넌트에 한 줄 말줄임 기능을 추가함으로써 카드 컴포넌트 개선

### DIFF
--- a/frontend/src/@common/components/Text/Text.style.ts
+++ b/frontend/src/@common/components/Text/Text.style.ts
@@ -28,9 +28,14 @@ const textVariant: Record<TextVariantProps, SerializedStyles> = {
 };
 
 export const TextStyle = ({ color, variant }: TextProps) => css`
+  overflow: hidden;
+
   box-sizing: border-box;
   max-width: 100%;
-  color: ${color ?? theme.colors.black};
 
+  color: ${color ?? theme.colors.black};
   ${variant && textVariant[variant]}
+
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
장소 카드의 정보의 길이가 긴 경우 줄이 밀려나며 장소 카드의 길이가 유동적으로 변하는 문제 발견

## To-Be
<!-- 변경 사항 -->
카드 컴포넌트의 가로 크기에 맞추어 정보를 자르고 ... 으로 표현하도록 수정  


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="931" height="500" alt="스크린샷 2025-08-12 오전 11 00 51" src="https://github.com/user-attachments/assets/9e2ddbe7-60fc-453d-9dea-079709cafe9d" />


## (Optional) Additional Description


Closes #445
