### PR TITLE
refactor: 모든 Service 클래스에서 @Transactional(readOnly = true)를 사용하도록 변경

### DIFF
--- a/backend/spring-routie/src/main/java/routie/place/service/PlaceSearchService.java
+++ b/backend/spring-routie/src/main/java/routie/place/service/PlaceSearchService.java
@@ -3,12 +3,14 @@ package routie.place.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import routie.place.controller.dto.response.SearchedPlacesResponse;
 import routie.place.domain.PlaceSearcher;
 import routie.place.domain.SearchedPlace;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PlaceSearchService {
 
     private final PlaceSearcher placeSearcher;

--- a/backend/spring-routie/src/main/java/routie/place/service/PlaceService.java
+++ b/backend/spring-routie/src/main/java/routie/place/service/PlaceService.java
@@ -17,6 +17,7 @@ import routie.routiespace.repository.RoutieSpaceRepository;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PlaceService {
 
     private final PlaceRepository placeRepository;

--- a/backend/spring-routie/src/main/java/routie/routie/service/RoutieService.java
+++ b/backend/spring-routie/src/main/java/routie/routie/service/RoutieService.java
@@ -36,7 +36,9 @@ import routie.routiespace.repository.RoutieSpaceRepository;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RoutieService {
+
     private static final int MIN_ROUTIE_PLACES_FOR_ROUTE = 2;
 
     private final RoutieSpaceRepository routieSpaceRepository;

--- a/backend/spring-routie/src/main/java/routie/routiespace/service/RoutieSpaceService.java
+++ b/backend/spring-routie/src/main/java/routie/routiespace/service/RoutieSpaceService.java
@@ -19,7 +19,6 @@ public class RoutieSpaceService {
     private final RoutieSpaceRepository routieSpaceRepository;
     private final RoutieSpaceIdentifierProvider routieSpaceIdentifierProvider;
 
-    @Transactional(readOnly = true)
     public RoutieSpaceReadResponse getRoutieSpace(final String routieSpaceIdentifier) {
         RoutieSpace routieSpace = getRoutieSpaceByRoutieSpaceIdentifier(routieSpaceIdentifier);
 

--- a/backend/spring-routie/src/main/java/routie/routiespace/service/RoutieSpaceService.java
+++ b/backend/spring-routie/src/main/java/routie/routiespace/service/RoutieSpaceService.java
@@ -13,6 +13,7 @@ import routie.routiespace.repository.RoutieSpaceRepository;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RoutieSpaceService {
 
     private final RoutieSpaceRepository routieSpaceRepository;


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
Service 의 클래스 단위에 `@Transactional(readOnly = true)`이 없어 메서드 단위에서 어노테이션을 명시했어야 함.
개발자가 빼먹을 수 있었음.

## To-Be
<!-- 변경 사항 -->
모든 Service 클래스에서 `@Transactional(readOnly = true)`를 사용하도록 변경.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
DB 를 사용하지 않는 public 메서드에 대해 트랜잭션이 열린다는 단점이 있음.
사소한 오버헤드가 존재하지만, 개발자가 어노테이션을 빼먹는 것을 방지하는 것이 더욱 가치있다고 판단.

Closes #439 