### PR TITLE
fix: 카카오맵 기본 위치 좌표 수정

### DIFF
--- a/frontend/src/domains/maps/components/KakaoMap.tsx
+++ b/frontend/src/domains/maps/components/KakaoMap.tsx
@@ -20,11 +20,7 @@ import {
 
 import type { KakaoMapProps } from '../types/KaKaoMap.types';
 
-const KakaoMap = ({
-  lat = 37.5665,
-  lng = 126.978,
-  level = 3,
-}: KakaoMapProps) => {
+const KakaoMap = ({ lat = 36.5, lng = 127.8, level = 13 }: KakaoMapProps) => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const { placeList } = usePlaceListContext();
   const { routieIdList } = useRoutieContext();


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
지도 첫 화면이 서울 시청 좌표로 되어있어서 사용자가 들어와서 이 좌표가 어디인지 궁금증을 갖게 되는 문제 발견

## To-Be
<!-- 변경 사항 -->
한국 전역 지도를 보여줌으로써 위의 문제를 해결한다. 


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="1175" height="674" alt="스크린샷 2025-08-12 오후 1 22 52" src="https://github.com/user-attachments/assets/12299c67-98af-49e7-92b8-1b6fe38d3746" />


## (Optional) Additional Description

Closes #455 
