### PR TITLE
refactor: 빈 루티에 대한 안내 메세지를 직관적으로 변경

### DIFF
--- a/frontend/src/domains/routie/components/EmptyRoutieMessage/EmptyRoutieMessage.tsx
+++ b/frontend/src/domains/routie/components/EmptyRoutieMessage/EmptyRoutieMessage.tsx
@@ -3,12 +3,12 @@ import Text from '@/@common/components/Text/Text';
 import theme from '@/styles/theme';
 
 const EmptyRoutieMessage = () => (
-  <Flex width="100%" direction="column" padding={8} gap={1}>
+  <Flex width="100%" direction="column" gap={1} css={{ padding: '8rem 0' }}>
     <Text variant="subTitle" color={theme.colors.gray[200]}>
-      동선이 생성되지 않았어요.
+      아직 동선이 없습니다.
     </Text>
     <Text variant="subTitle" color={theme.colors.gray[200]}>
-      장소를 2개 이상 추가하면 동선이 생성됩니다!
+      장소 목록에서 2곳 이상을 선택하면 동선이 생성됩니다!
     </Text>
   </Flex>
 );


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
루티가 비어있을 때 안내 메세지가 직관적이지 않음

## To-Be
<!-- 변경 사항 -->
루티가 비어있을 때 안내 메세지를 직관적으로 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="721" height="360" alt="image" src="https://github.com/user-attachments/assets/7c510d8e-7379-4bb8-afa2-d8703877289f" />

## (Optional) Additional Description
- 직관적으로 변했나요... 더 좋은 문구가 있다면 추천 받습니다.

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
close #450
