### PR TITLE
fix: 장소 수정 후 동기화 되지 않아 의존성 수정

### DIFF
--- a/frontend/src/domains/routie/components/RoutiePlaceCard/RoutiePlaceCard.tsx
+++ b/frontend/src/domains/routie/components/RoutiePlaceCard/RoutiePlaceCard.tsx
@@ -25,7 +25,7 @@ const RoutiePlaceCard = ({ routie }: { routie: Routie }) => {
       setPlace(detailPlace);
     };
     fetchDetailPlace();
-  }, [routie.placeId]);
+  }, [routie]);
 
   const handleDelete = () => {
     handleDeleteRoutie(routie.placeId);


### PR DESCRIPTION
## As-Is
- 장소 목록에서 장소 수정 후 변경된 내용이 루티 장소에서 업데이트 되지 않음.


## To-Be
- 루티 장소 컴포넌트에서 호출되는 useEffect 의존성 수정.
- 장소 목록에서 장소 수정 후 변경된 내용이 루티 장소에서 업데이트.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/75fb0c2b-f49e-4d2c-9cbe-b4785bc62dcb




## (Optional) Additional Description


Closes #436 

