### PR TITLE
feat: 장소 추가 모달에서 관심사에 따라 funnel로 분리

### DIFF
--- a/.github/workflows/setup-open-pr.yml
+++ b/.github/workflows/setup-open-pr.yml
@@ -68,7 +68,7 @@ jobs:
             // 1. PR 제목 prefix 기반 라벨 추가
             const title = pr.title.toLowerCase();
             const titleLabelMap = {
-                'feat': 'feat',
+                'feat': 'feature',
                 'fix': 'fix',
                 'docs': 'docs',
                 'style': 'style',

--- a/backend/spring-routie/src/main/java/routie/place/domain/Place.java
+++ b/backend/spring-routie/src/main/java/routie/place/domain/Place.java
@@ -71,7 +71,7 @@ public class Place {
     @JoinColumn(name = "routie_space_id")
     private RoutieSpace routieSpace;
 
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     @JoinColumn(name = "place_id", nullable = false)
     private List<PlaceClosedDayOfWeek> placeClosedDayOfWeeks = new ArrayList<>();
 

--- a/backend/spring-routie/src/main/java/routie/place/domain/PlaceClosedDayOfWeek.java
+++ b/backend/spring-routie/src/main/java/routie/place/domain/PlaceClosedDayOfWeek.java
@@ -20,13 +20,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @Entity
-@Table(
-        name = "place_closed_dayofweeks", uniqueConstraints = {
-//                @UniqueConstraint(
-//                        name = "uk_place_closed_day", columnNames = {"place_id", "closed_day"}
-//                )
-}
-)
+@Table(name = "place_closed_dayofweeks")
 @EntityListeners(AuditingEntityListener.class)
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/spring-routie/src/main/java/routie/place/service/PlaceService.java
+++ b/backend/spring-routie/src/main/java/routie/place/service/PlaceService.java
@@ -71,9 +71,6 @@ public class PlaceService {
         final RoutieSpace routieSpace = getRoutieSpaceByIdentifier(routieSpaceIdentifier);
         final Place place = getPlaceByIdAndRoutieSpace(placeId, routieSpace);
 
-        place.getPlaceClosedDayOfWeeks()
-                .forEach(closedDayOfWeek -> placeClosedDayOfWeekRepository.deleteById(closedDayOfWeek.getId()));
-
         place.modify(
                 placeUpdateRequest.stayDurationMinutes(),
                 placeUpdateRequest.openAt(),

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,7 +8,7 @@
       src="//dapi.kakao.com/v2/maps/sdk.js?appkey=00b645bb62b130f378513e9f32324901&autoload=false"
       async
     ></script>
-    <title>Document</title>
+    <title>Routie</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/domains/places/apis/searchPlace.ts
+++ b/frontend/src/domains/places/apis/searchPlace.ts
@@ -14,7 +14,7 @@ const searchPlace = async (keyword: string) => {
 
   const data = await response.json();
 
-  return data.searchPlaces;
+  return data.searchedPlaces;
 };
 
 export default searchPlace;

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceBasicInfo.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceBasicInfo.tsx
@@ -1,0 +1,55 @@
+import Flex from '@/@common/components/Flex/Flex';
+
+import { PlaceLocationType } from '../../types/place.types';
+import AddressInput from '../PlaceFormSection/AddressInput';
+import { FormState } from '../PlaceFormSection/PlaceForm.types';
+import PlaceNameInput from '../PlaceFormSection/PlaceNameInput';
+import StayDurationInput from '../PlaceFormSection/StayDurationInput';
+import SearchBox from '../SearchBox/SearchBox';
+
+interface AddPlaceBasicInfoProps {
+  form: FormState;
+  isEmpty: Record<string, boolean>;
+  showErrors: boolean;
+  handleInputChange: (
+    field: keyof Omit<FormState, 'closedDayOfWeeks'>,
+    value: string,
+  ) => void;
+  handleSearchPlaceMap: (placeLocation: PlaceLocationType) => void;
+}
+
+const AddPlaceBasicInfo = ({
+  form,
+  isEmpty,
+  showErrors,
+  handleInputChange,
+  handleSearchPlaceMap,
+}: AddPlaceBasicInfoProps) => {
+  return (
+    <Flex direction="column" alignItems="flex-start" width="100%" gap={2}>
+      <SearchBox
+        onChange={handleInputChange}
+        handleSearchPlaceMap={handleSearchPlaceMap}
+      />
+      <PlaceNameInput
+        value={form.name}
+        onChange={handleInputChange}
+        error={showErrors && isEmpty.name}
+        disabled
+      />
+      <AddressInput
+        value={form.roadAddressName}
+        onChange={handleInputChange}
+        error={showErrors && isEmpty.roadAddressName}
+        disabled
+      />
+      <StayDurationInput
+        value={form.stayDurationMinutes}
+        onChange={handleInputChange}
+        error={showErrors && isEmpty.stayDurationMinutes}
+      />
+    </Flex>
+  );
+};
+
+export default AddPlaceBasicInfo;

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
@@ -9,6 +9,7 @@ import { usePlaceFormValidation } from '@/domains/places/hooks/usePlaceFormValid
 import addPlace from '../../apis/addPlace';
 import { useFunnel } from '../../hooks/useFunnel';
 import { PlaceLocationType } from '../../types/place.types';
+import { getValidatedStep } from '../../utils/getValidatedStep';
 
 import AddPlaceBasicInfo from './AddPlaceBasicInfo';
 import { ModalInputContainerStyle } from './AddPlaceModal.styles';
@@ -33,9 +34,7 @@ const AddPlaceModal = ({
   const [showErrors, setShowErrors] = useState(false);
   const [placeLocationInfo, setPlaceLocationInfo] =
     useState<PlaceLocationType>();
-
-  const isStep1Valid =
-    !isEmpty.name && !isEmpty.roadAddressName && !isEmpty.stayDurationMinutes;
+  const isStep1Valid = getValidatedStep(1, isEmpty);
 
   const handleClose = () => {
     resetForm();

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
@@ -2,23 +2,19 @@ import { useState } from 'react';
 
 import Flex from '@/@common/components/Flex/Flex';
 import Modal, { ModalProps } from '@/@common/components/Modal/Modal';
+import Text from '@/@common/components/Text/Text';
 import { useAddPlaceForm } from '@/domains/places/hooks/useAddPlaceForm';
+import { usePlaceFormValidation } from '@/domains/places/hooks/usePlaceFormValidation';
 
 import addPlace from '../../apis/addPlace';
-import { usePlaceFormValidation } from '../../hooks/usePlaceFormValidation';
-import useSearchPlace from '../../hooks/useSearchPlace';
+import { useFunnel } from '../../hooks/useFunnel';
 import { PlaceLocationType } from '../../types/place.types';
-import AddressInput from '../PlaceFormSection/AddressInput';
-import BreakTimeInputs from '../PlaceFormSection/BreakTimeInputs';
-import BusinessHourInputs from '../PlaceFormSection/BusinessHourInputs';
-import ClosedDaySelector from '../PlaceFormSection/ClosedDaySelector';
-import PlaceNameInput from '../PlaceFormSection/PlaceNameInput';
-import StayDurationInput from '../PlaceFormSection/StayDurationInput';
-import SearchBox from '../SearchBox/SearchBox';
 
+import AddPlaceBasicInfo from './AddPlaceBasicInfo';
 import { ModalInputContainerStyle } from './AddPlaceModal.styles';
 import AddPlaceModalButtons from './AddPlaceModalButtons';
 import AddPlaceModalHeader from './AddPlaceModalHeader';
+import AddPlaceVerification from './AddPlaceVerification';
 
 interface AddPlaceModalProps extends Omit<ModalProps, 'children'> {
   onPlaceAdded?: () => Promise<void>;
@@ -32,18 +28,38 @@ const AddPlaceModal = ({
   const { form, handleInputChange, handleToggleDay, resetForm } =
     useAddPlaceForm();
   const { isEmpty, isValid } = usePlaceFormValidation(form);
+  const { step, nextStep, prevStep, resetFunnel } = useFunnel();
+
   const [showErrors, setShowErrors] = useState(false);
   const [placeLocationInfo, setPlaceLocationInfo] =
     useState<PlaceLocationType>();
 
+  const isStep1Valid =
+    !isEmpty.name && !isEmpty.roadAddressName && !isEmpty.stayDurationMinutes;
+
   const handleClose = () => {
     resetForm();
+    resetFunnel();
     setShowErrors(false);
     onClose();
   };
 
   const handleSearchPlaceMap = (placeLocation: PlaceLocationType) => {
     setPlaceLocationInfo(placeLocation);
+  };
+
+  const handleNext = () => {
+    if (!isStep1Valid) {
+      setShowErrors(true);
+      return;
+    }
+    setShowErrors(false);
+    nextStep();
+  };
+
+  const handlePrev = () => {
+    setShowErrors(false);
+    prevStep();
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -54,6 +70,7 @@ const AddPlaceModal = ({
       setShowErrors(true);
       return;
     }
+
     try {
       await addPlace(addPlaceForm);
       if (onPlaceAdded) {
@@ -65,64 +82,52 @@ const AddPlaceModal = ({
     handleClose();
   };
 
+  const renderContent = () => {
+    if (step === 1) {
+      return (
+        <AddPlaceBasicInfo
+          form={form}
+          isEmpty={isEmpty}
+          showErrors={showErrors}
+          handleInputChange={handleInputChange}
+          handleSearchPlaceMap={handleSearchPlaceMap}
+        />
+      );
+    }
+    if (step === 2) {
+      return (
+        <AddPlaceVerification
+          form={form}
+          isEmpty={isEmpty}
+          showErrors={showErrors}
+          handleInputChange={handleInputChange}
+          handleToggleDay={handleToggleDay}
+        />
+      );
+    }
+    return null;
+  };
+
   return (
     <Modal isOpen={isOpen} onClose={handleClose}>
       <form onSubmit={handleSubmit}>
         <Flex direction="column" width="44rem" gap={2}>
           <AddPlaceModalHeader onClose={handleClose} />
-          <div css={ModalInputContainerStyle}>
-            <Flex
-              direction="column"
-              alignItems="flex-start"
-              width="100%"
-              gap={2}
-            >
-              <SearchBox
-                onChange={handleInputChange}
-                handleSearchPlaceMap={handleSearchPlaceMap}
-              />
-              {form.name && (
-                <PlaceNameInput
-                  value={form.name}
-                  onChange={handleInputChange}
-                  error={showErrors && isEmpty.name}
-                  disabled
-                />
-              )}
-              {form.roadAddressName && (
-                <AddressInput
-                  value={form.roadAddressName}
-                  onChange={handleInputChange}
-                  error={showErrors && isEmpty.roadAddressName}
-                  disabled
-                />
-              )}
-              <StayDurationInput
-                value={form.stayDurationMinutes}
-                onChange={handleInputChange}
-                error={showErrors && isEmpty.stayDurationMinutes}
-              />
-              <BusinessHourInputs
-                openAt={form.openAt}
-                closeAt={form.closeAt}
-                onChange={handleInputChange}
-                error={{
-                  openAt: showErrors && isEmpty.openAt,
-                  closeAt: showErrors && isEmpty.closeAt,
-                }}
-              />
-              <BreakTimeInputs
-                breakStartAt={form.breakStartAt}
-                breakEndAt={form.breakEndAt}
-                onChange={handleInputChange}
-              />
-              <ClosedDaySelector
-                closedDayOfWeeks={form.closedDayOfWeeks}
-                onToggleDay={handleToggleDay}
-              />
-            </Flex>
-          </div>
-          <AddPlaceModalButtons />
+          <Flex justifyContent="flex-start" gap={1.6} width="100%">
+            <Text variant="caption" css={step === 1 && { fontWeight: 700 }}>
+              1. 기본 정보
+            </Text>
+            <Text variant="caption" css={step === 2 && { fontWeight: 700 }}>
+              2. 검증 정보
+            </Text>
+          </Flex>
+          <div css={ModalInputContainerStyle}>{renderContent()}</div>
+          <AddPlaceModalButtons
+            step={step}
+            isStep1Valid={isStep1Valid}
+            onNext={handleNext}
+            onPrev={handlePrev}
+          />
         </Flex>
       </form>
     </Modal>

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
@@ -29,7 +29,8 @@ const AddPlaceModal = ({
   const { form, handleInputChange, handleToggleDay, resetForm } =
     useAddPlaceForm();
   const { isEmpty, isValid } = usePlaceFormValidation(form);
-  const { step, nextStep, prevStep, resetFunnel } = useFunnel();
+  const { step, nextStep, prevStep, resetFunnel, isStep1, isStep2 } =
+    useFunnel();
 
   const [showErrors, setShowErrors] = useState(false);
   const [placeLocationInfo, setPlaceLocationInfo] =
@@ -114,10 +115,10 @@ const AddPlaceModal = ({
         <Flex direction="column" width="44rem" gap={2}>
           <AddPlaceModalHeader onClose={handleClose} />
           <Flex justifyContent="flex-start" gap={1.6} width="100%">
-            <Text variant="caption" css={step === 1 && { fontWeight: 700 }}>
+            <Text variant="caption" css={isStep1 && { fontWeight: 700 }}>
               1. 기본 정보
             </Text>
-            <Text variant="caption" css={step === 2 && { fontWeight: 700 }}>
+            <Text variant="caption" css={isStep2 && { fontWeight: 700 }}>
               2. 검증 정보
             </Text>
           </Flex>

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
@@ -14,7 +14,7 @@ import AddPlaceBasicInfo from './AddPlaceBasicInfo';
 import { ModalInputContainerStyle } from './AddPlaceModal.styles';
 import AddPlaceModalButtons from './AddPlaceModalButtons';
 import AddPlaceModalHeader from './AddPlaceModalHeader';
-import AddPlaceVerification from './AddPlaceVerification';
+import AddPlaceValidation from './AddPlaceValidation';
 
 interface AddPlaceModalProps extends Omit<ModalProps, 'children'> {
   onPlaceAdded?: () => Promise<void>;
@@ -96,7 +96,7 @@ const AddPlaceModal = ({
         );
       case 2:
         return (
-          <AddPlaceVerification
+          <AddPlaceValidation
             form={form}
             isEmpty={isEmpty}
             showErrors={showErrors}

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
@@ -83,29 +83,30 @@ const AddPlaceModal = ({
   };
 
   const renderContent = () => {
-    if (step === 1) {
-      return (
-        <AddPlaceBasicInfo
-          form={form}
-          isEmpty={isEmpty}
-          showErrors={showErrors}
-          handleInputChange={handleInputChange}
-          handleSearchPlaceMap={handleSearchPlaceMap}
-        />
-      );
+    switch (step) {
+      case 1:
+        return (
+          <AddPlaceBasicInfo
+            form={form}
+            isEmpty={isEmpty}
+            showErrors={showErrors}
+            handleInputChange={handleInputChange}
+            handleSearchPlaceMap={handleSearchPlaceMap}
+          />
+        );
+      case 2:
+        return (
+          <AddPlaceVerification
+            form={form}
+            isEmpty={isEmpty}
+            showErrors={showErrors}
+            handleInputChange={handleInputChange}
+            handleToggleDay={handleToggleDay}
+          />
+        );
+      default:
+        return <></>;
     }
-    if (step === 2) {
-      return (
-        <AddPlaceVerification
-          form={form}
-          isEmpty={isEmpty}
-          showErrors={showErrors}
-          handleInputChange={handleInputChange}
-          handleToggleDay={handleToggleDay}
-        />
-      );
-    }
-    return null;
   };
 
   return (

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModalButtons.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModalButtons.tsx
@@ -1,17 +1,57 @@
 import Button from '@/@common/components/Button/Button';
 import Flex from '@/@common/components/Flex/Flex';
 import Text from '@/@common/components/Text/Text';
+import theme from '@/styles/theme';
 
-const AddPlaceModalButtons = () => {
+interface AddPlaceModalButtonsProps {
+  step: 1 | 2;
+  isStep1Valid: boolean;
+  onNext: () => void;
+  onPrev: () => void;
+}
+
+const AddPlaceModalButtons = ({
+  step,
+  isStep1Valid,
+  onNext,
+  onPrev,
+}: AddPlaceModalButtonsProps) => {
   return (
-    <Flex justifyContent="space-between" width="100%" gap={1.6}>
-      <Button type="submit" variant="primary">
-        <Flex width="100%">
-          <Text variant="caption" color="white">
-            추가하기
-          </Text>
+    <Flex justifyContent="flex-end" gap={1} width="100%">
+      {step === 1 ? (
+        <Flex justifyContent="flex-end" width="50%">
+          <Button
+            variant="primary"
+            onClick={onNext}
+            disabled={!isStep1Valid}
+            width="50%"
+            type="button"
+          >
+            <Flex width="100%">
+              <Text variant="caption" color={theme.colors.white}>
+                다음
+              </Text>
+            </Flex>
+          </Button>
         </Flex>
-      </Button>
+      ) : (
+        <Flex width="50%" gap={1}>
+          <Button variant="secondary" onClick={onPrev} type="button">
+            <Flex width="100%">
+              <Text variant="caption" color={theme.colors.purple[400]}>
+                이전
+              </Text>
+            </Flex>
+          </Button>
+          <Button variant="primary" type="submit">
+            <Flex width="100%">
+              <Text variant="caption" color={theme.colors.white}>
+                추가하기
+              </Text>
+            </Flex>
+          </Button>
+        </Flex>
+      )}
     </Flex>
   );
 };

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceValidation.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceValidation.tsx
@@ -5,7 +5,7 @@ import BusinessHourInputs from '../PlaceFormSection/BusinessHourInputs';
 import ClosedDaySelector from '../PlaceFormSection/ClosedDaySelector';
 import { FormState } from '../PlaceFormSection/PlaceForm.types';
 
-interface AddPlaceVerificationProps {
+interface AddPlaceValidationProps {
   form: FormState;
   isEmpty: Record<string, boolean>;
   showErrors: boolean;
@@ -16,13 +16,13 @@ interface AddPlaceVerificationProps {
   handleToggleDay: (index: number) => void;
 }
 
-const AddPlaceVerification = ({
+const AddPlaceValidation = ({
   form,
   isEmpty,
   showErrors,
   handleInputChange,
   handleToggleDay,
-}: AddPlaceVerificationProps) => {
+}: AddPlaceValidationProps) => {
   return (
     <Flex direction="column" alignItems="flex-start" width="100%" gap={2}>
       <BusinessHourInputs
@@ -47,4 +47,4 @@ const AddPlaceVerification = ({
   );
 };
 
-export default AddPlaceVerification;
+export default AddPlaceValidation;

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceVerification.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceVerification.tsx
@@ -1,0 +1,50 @@
+import Flex from '@/@common/components/Flex/Flex';
+
+import BreakTimeInputs from '../PlaceFormSection/BreakTimeInputs';
+import BusinessHourInputs from '../PlaceFormSection/BusinessHourInputs';
+import ClosedDaySelector from '../PlaceFormSection/ClosedDaySelector';
+import { FormState } from '../PlaceFormSection/PlaceForm.types';
+
+interface AddPlaceVerificationProps {
+  form: FormState;
+  isEmpty: Record<string, boolean>;
+  showErrors: boolean;
+  handleInputChange: (
+    field: keyof Omit<FormState, 'closedDayOfWeeks'>,
+    value: string,
+  ) => void;
+  handleToggleDay: (index: number) => void;
+}
+
+const AddPlaceVerification = ({
+  form,
+  isEmpty,
+  showErrors,
+  handleInputChange,
+  handleToggleDay,
+}: AddPlaceVerificationProps) => {
+  return (
+    <Flex direction="column" alignItems="flex-start" width="100%" gap={2}>
+      <BusinessHourInputs
+        openAt={form.openAt}
+        closeAt={form.closeAt}
+        onChange={handleInputChange}
+        error={{
+          openAt: showErrors && isEmpty.openAt,
+          closeAt: showErrors && isEmpty.closeAt,
+        }}
+      />
+      <BreakTimeInputs
+        breakStartAt={form.breakStartAt}
+        breakEndAt={form.breakEndAt}
+        onChange={handleInputChange}
+      />
+      <ClosedDaySelector
+        closedDayOfWeeks={form.closedDayOfWeeks}
+        onToggleDay={handleToggleDay}
+      />
+    </Flex>
+  );
+};
+
+export default AddPlaceVerification;

--- a/frontend/src/domains/places/components/PlaceFormSection/AddressInput.tsx
+++ b/frontend/src/domains/places/components/PlaceFormSection/AddressInput.tsx
@@ -1,5 +1,6 @@
 import Flex from '@/@common/components/Flex/Flex';
 import Input from '@/@common/components/Input/Input';
+import theme from '@/styles/theme';
 
 interface AddressInputProps {
   value: string;
@@ -8,14 +9,7 @@ interface AddressInputProps {
   error?: boolean;
 }
 
-const AddressInput = ({
-  value,
-  onChange,
-  disabled,
-  error = false,
-}: AddressInputProps) => {
-  const inputVariant = disabled ? 'disabled' : error ? 'error' : 'primary';
-
+const AddressInput = ({ value, onChange }: AddressInputProps) => {
   return (
     <Flex direction="column" alignItems="flex-start" gap={1} width="100%">
       <Input
@@ -23,8 +17,13 @@ const AddressInput = ({
         value={value}
         onChange={(value) => onChange('roadAddressName', value)}
         label="주소"
-        placeholder="장소의 주소를 입력해주세요"
-        variant={inputVariant}
+        placeholder="검색을 통해 장소 주소를 넣어주세요"
+        variant="disabled"
+        css={{
+          '::placeholder': {
+            color: `${theme.colors.gray[300]}`,
+          },
+        }}
       />
     </Flex>
   );

--- a/frontend/src/domains/places/components/PlaceFormSection/BusinessHourInputs.tsx
+++ b/frontend/src/domains/places/components/PlaceFormSection/BusinessHourInputs.tsx
@@ -30,6 +30,7 @@ const BusinessHourInputs = ({
             onChange={(value) => onChange('openAt', value)}
             variant={error?.openAt ? 'error' : 'primary'}
             label="오픈 시간"
+            autoFocus
           />
         </Flex>
         <Flex direction="column" alignItems="flex-start" gap={1} width="100%">

--- a/frontend/src/domains/places/components/PlaceFormSection/PlaceForm.types.ts
+++ b/frontend/src/domains/places/components/PlaceFormSection/PlaceForm.types.ts
@@ -1,6 +1,7 @@
 export type FormState = {
   name: string;
   roadAddressName: string;
+  addressName: string;
   stayDurationMinutes: number;
   openAt: string;
   closeAt: string;

--- a/frontend/src/domains/places/components/PlaceFormSection/PlaceNameInput.tsx
+++ b/frontend/src/domains/places/components/PlaceFormSection/PlaceNameInput.tsx
@@ -1,5 +1,6 @@
 import Flex from '@/@common/components/Flex/Flex';
 import Input from '@/@common/components/Input/Input';
+import theme from '@/styles/theme';
 
 interface PlaceNameInputProps {
   value: string;
@@ -8,14 +9,7 @@ interface PlaceNameInputProps {
   error?: boolean;
 }
 
-const PlaceNameInput = ({
-  value,
-  onChange,
-  disabled,
-  error = false,
-}: PlaceNameInputProps) => {
-  const inputVariant = disabled ? 'disabled' : error ? 'error' : 'primary';
-
+const PlaceNameInput = ({ value, onChange }: PlaceNameInputProps) => {
   return (
     <Flex direction="column" alignItems="flex-start" gap={1} width="100%">
       <Input
@@ -23,8 +17,13 @@ const PlaceNameInput = ({
         value={value}
         onChange={(value) => onChange('name', value)}
         label="이름"
-        placeholder="장소의 이름을 입력해주세요"
-        variant={inputVariant}
+        placeholder="검색을 통해 장소 이름을 넣어주세요"
+        variant="disabled"
+        css={{
+          '::placeholder': {
+            color: `${theme.colors.gray[300]}`,
+          },
+        }}
       />
     </Flex>
   );

--- a/frontend/src/domains/places/components/SearchBox/SearchBox.tsx
+++ b/frontend/src/domains/places/components/SearchBox/SearchBox.tsx
@@ -9,7 +9,10 @@ import { PlaceLocationType, PlaceSearchType } from '../../types/place.types';
 import SearchList from '../SearchList/SearchList';
 
 interface SearchBoxProps {
-  onChange: (field: 'name' | 'roadAddressName', value: string) => void;
+  onChange: (
+    field: 'name' | 'roadAddressName' | 'addressName',
+    value: string,
+  ) => void;
   handleSearchPlaceMap: (searchInfo: PlaceLocationType) => void;
 }
 
@@ -27,6 +30,7 @@ const SearchBox = ({ onChange, handleSearchPlaceMap }: SearchBoxProps) => {
     handleReset();
     onChange('name', searchPlace.name);
     onChange('roadAddressName', searchPlace.roadAddressName);
+    onChange('addressName', searchPlace.addressName);
 
     handleSearchPlaceMap({
       searchedPlaceId: searchPlace.searchedPlaceId,
@@ -37,7 +41,7 @@ const SearchBox = ({ onChange, handleSearchPlaceMap }: SearchBoxProps) => {
 
   return (
     <>
-      <Flex direction="row" gap={1} width="100%">
+      <Flex direction="row" gap={1} width="100%" css={{ position: 'relative' }}>
         <Input
           id="search"
           value={keyword}
@@ -45,6 +49,7 @@ const SearchBox = ({ onChange, handleSearchPlaceMap }: SearchBoxProps) => {
           placeholder="장소를 검색하세요"
           onChange={handleChangeKeyword}
           onKeyDown={handleEnterSearch}
+          autoFocus
         />
         <Button
           variant="primary"
@@ -58,14 +63,17 @@ const SearchBox = ({ onChange, handleSearchPlaceMap }: SearchBoxProps) => {
             </Text>
           </Flex>
         </Button>
-      </Flex>
-      <Flex width="100%" css={{ position: 'relative' }}>
-        {searchResults.length > 0 && (
-          <SearchList
-            searchResults={searchResults}
-            handleSelect={handleSelect}
-          />
-        )}
+        <Flex
+          width="100%"
+          css={{ position: 'absolute', top: '100%', marginTop: '1rem' }}
+        >
+          {searchResults.length > 0 && (
+            <SearchList
+              searchResults={searchResults}
+              handleSelect={handleSelect}
+            />
+          )}
+        </Flex>
       </Flex>
     </>
   );

--- a/frontend/src/domains/places/constants/step.ts
+++ b/frontend/src/domains/places/constants/step.ts
@@ -1,0 +1,4 @@
+export const STEP_REQUIRED_FIELDS = {
+  1: ['name', 'roadAddressName', 'stayDurationMinutes'],
+  2: ['openAt', 'closeAt', 'closedDayOfWeeks'],
+};

--- a/frontend/src/domains/places/hooks/useAddPlaceForm.ts
+++ b/frontend/src/domains/places/hooks/useAddPlaceForm.ts
@@ -17,6 +17,7 @@ const initialFormState: FormState = {
   breakStartAt: '',
   breakEndAt: '',
   closedDayOfWeeks: [],
+  addressName: '',
 };
 
 const formReducer = (state: FormState, action: FormAction): FormState => {

--- a/frontend/src/domains/places/hooks/useFunnel.ts
+++ b/frontend/src/domains/places/hooks/useFunnel.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 type StepType = 1 | 2;
 
@@ -17,10 +17,15 @@ export const useFunnel = () => {
     setStep(1);
   };
 
+  const isStep1 = useMemo(() => step === 1, [step]);
+  const isStep2 = useMemo(() => step === 2, [step]);
+
   return {
     step,
     nextStep,
     prevStep,
     resetFunnel,
+    isStep1,
+    isStep2,
   };
 };

--- a/frontend/src/domains/places/hooks/useFunnel.ts
+++ b/frontend/src/domains/places/hooks/useFunnel.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+type StepType = 1 | 2;
+
+export const useFunnel = () => {
+  const [step, setStep] = useState<StepType>(1);
+
+  const nextStep = () => {
+    setStep((prev) => (prev === 1 ? 2 : prev));
+  };
+
+  const prevStep = () => {
+    setStep((prev) => (prev === 2 ? 1 : prev));
+  };
+
+  const resetFunnel = () => {
+    setStep(1);
+  };
+
+  return {
+    step,
+    nextStep,
+    prevStep,
+    resetFunnel,
+  };
+};

--- a/frontend/src/domains/places/hooks/useSearchPlace.ts
+++ b/frontend/src/domains/places/hooks/useSearchPlace.ts
@@ -42,8 +42,6 @@ const useSearchPlace = () => {
     setSearchResults,
     handleSearch,
     handleReset,
-    // placeLocation,
-    // handleSearchPlaceMap,
   };
 };
 

--- a/frontend/src/domains/places/types/place.types.ts
+++ b/frontend/src/domains/places/types/place.types.ts
@@ -7,11 +7,13 @@ export type PlaceLocationType = {
 export type PlaceSearchType = PlaceLocationType & {
   name: string;
   roadAddressName: string;
+  addressName: string;
 };
 
 export type PlaceBaseType = {
   name: string;
   roadAddressName: string;
+  addressName: string;
   stayDurationMinutes: number;
   openAt: string;
   closeAt: string;

--- a/frontend/src/domains/places/utils/getValidatedStep.ts
+++ b/frontend/src/domains/places/utils/getValidatedStep.ts
@@ -1,0 +1,8 @@
+import { STEP_REQUIRED_FIELDS } from '../constants/step';
+
+export const getValidatedStep = (
+  step: 1 | 2,
+  isEmpty: Record<string, boolean>,
+) => {
+  return STEP_REQUIRED_FIELDS[step].every((key) => !isEmpty[key]);
+};


### PR DESCRIPTION
## As-Is
- 하나의 장소 추가 모달에서 전체 입력 값이 있어 사용자 경험이 좋지 않음
- 장소 추가 모달 활성화 시 커서가 모달 밖에 있음
- 장소 검색에 따라 이름, 장소 입력창이 생기면서 모달 높이가 옴직이는 문제

## To-Be
- funnel 적용으로 장소 정보와 검증 정보로 나뉘어 입력 받게 개선
- auto focus 속성으로 모달 활성화 되면 자동으로 포커싱 되도록 개선
- 처음부터 입력창에 장소 이름창과 주소창이 나와있고 placeholder로 검색 안내

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/c8d2a881-33e0-4259-8f70-4d7e2644850e


## (Optional) Additional Description

Closes #480 

