### PR TITLE
refactor: 일정 날짜, 시간 입력 분리

### DIFF
--- a/frontend/src/@common/components/Input/Input.style.ts
+++ b/frontend/src/@common/components/Input/Input.style.ts
@@ -29,8 +29,8 @@ const inputVariant: Record<InputVariantProps, SerializedStyles> = {
   `,
   disabled: css`
     cursor: not-allowed;
-    border-color: ${theme.colors.black};
-    background-color: ${theme.colors.gray[100]};
+    border: none;
+    background-color: ${theme.colors.gray[50]};
   `,
   error: css`
     border-color: ${theme.colors.red[100]};

--- a/frontend/src/@common/components/Input/Input.tsx
+++ b/frontend/src/@common/components/Input/Input.tsx
@@ -1,3 +1,4 @@
+import Text from '@/@common/components/Text/Text';
 import clockIcon from '@/assets/icons/clock.svg';
 import searchIcon from '@/assets/icons/search.svg';
 
@@ -27,7 +28,7 @@ const Input = ({
     <>
       {label && (
         <label css={InputLabelStyle} htmlFor={id}>
-          {label}
+          <Text variant="caption">{label}</Text>
         </label>
       )}
       <div css={InputContainerStyle}>

--- a/frontend/src/@common/hooks/useSessionStorage.ts
+++ b/frontend/src/@common/hooks/useSessionStorage.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState } from 'react';
+
+import { sessionStorageUtils } from '../utils/sessionStorage';
+
+export const useSessionStorage = <T>(
+  key: string,
+  defaultValue: T,
+): [T, (value: T) => void] => {
+  const [storedValue, setStoredValue] = useState<T>(() =>
+    sessionStorageUtils.get(key, defaultValue),
+  );
+
+  const setValue = useCallback(
+    (value: T) => {
+      setStoredValue(value);
+      sessionStorageUtils.set(key, value);
+    },
+    [key],
+  );
+
+  return [storedValue, setValue];
+};

--- a/frontend/src/@common/utils/format.ts
+++ b/frontend/src/@common/utils/format.ts
@@ -1,9 +1,31 @@
-export const getKoreanDateTimeISO = (date: Date) => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
+export const getKoreanCurrentDateISO = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
 
-  return `${year}-${month}-${day}T${hours}:${minutes}`;
+  return `${year}-${month}-${day}`;
+};
+
+export const getKoreanCurrentTimeHM = () => {
+  const now = new Date();
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+
+  return `${hours}:${minutes}`;
+};
+
+export const getCombineDateTime = (dateTime: {
+  date: string;
+  startTime: string;
+  endTime: string;
+}) => {
+  if (!dateTime.date || !dateTime.startTime || !dateTime.endTime) {
+    return { startDateTime: '', endDateTime: '' };
+  }
+
+  return {
+    startDateTime: `${dateTime.date}T${dateTime.startTime}:00`,
+    endDateTime: `${dateTime.date}T${dateTime.endTime}:00`,
+  };
 };

--- a/frontend/src/@common/utils/format.ts
+++ b/frontend/src/@common/utils/format.ts
@@ -7,7 +7,7 @@ export const getKoreanCurrentDateISO = () => {
   return `${year}-${month}-${day}`;
 };
 
-export const getKoreanCurrentTimeHM = () => {
+export const getCurrentTimeHM = () => {
   const now = new Date();
   const hours = String(now.getHours()).padStart(2, '0');
   const minutes = String(now.getMinutes()).padStart(2, '0');

--- a/frontend/src/@common/utils/sessionStorage.ts
+++ b/frontend/src/@common/utils/sessionStorage.ts
@@ -1,0 +1,27 @@
+export const sessionStorageUtils = {
+  get: <T>(key: string, defaultValue: T): T => {
+    try {
+      const item = sessionStorage.getItem(key);
+      return item ? JSON.parse(item) : defaultValue;
+    } catch (error) {
+      console.warn(`세션 스토리지 아이템 파싱 실패: '${key}':`, error);
+      return defaultValue;
+    }
+  },
+
+  set: <T>(key: string, value: T): void => {
+    try {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.error(`세션 스토리지 아이템 설정 실패: '${key}':`, error);
+    }
+  },
+
+  remove: (key: string): void => {
+    try {
+      sessionStorage.removeItem(key);
+    } catch (error) {
+      console.error(`세션 스토리지 아이템 삭제 실패: '${key}':`, error);
+    }
+  },
+};

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -100,11 +100,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
 
   useEffect(() => {
     refetchRoutieData();
-  }, [
-    isValidateActive,
-    combineDateTime.startDateTime,
-    combineDateTime.endDateTime,
-  ]);
+  }, [isValidateActive, combineDateTime]);
 
   return (
     <RoutieContext.Provider

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -40,14 +40,14 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
   const [routiePlaces, setRoutiePlaces] = useState<Routie[]>([]);
   const [routes, setRoutes] = useState<Routes[]>([]);
   const routieIdList = routiePlaces.map((routie) => routie.placeId);
-  const { isValidateActive, routieTime, validateRoutie } =
+  const { isValidateActive, combineDateTime, validateRoutie } =
     useRoutieValidateContext();
 
   const refetchRoutieData = useCallback(async () => {
     try {
       const routies = await getRoutie(
         isValidateActive,
-        routieTime.startDateTime,
+        combineDateTime.startDateTime,
       );
       setRoutiePlaces(routies.routiePlaces);
       setRoutes(routies.routes);
@@ -55,7 +55,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
     } catch (error) {
       console.error('루티 정보를 불러오는데 실패했습니다.', error);
     }
-  }, [isValidateActive, routieTime.startDateTime, validateRoutie]);
+  }, [isValidateActive, combineDateTime.startDateTime, validateRoutie]);
 
   const handleAddRoutie = useCallback(
     async (id: number) => {
@@ -102,9 +102,8 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
     refetchRoutieData();
   }, [
     isValidateActive,
-    routieTime.startDateTime,
-    routieTime.endDateTime,
-    refetchRoutieData,
+    combineDateTime.startDateTime,
+    combineDateTime.endDateTime,
   ]);
 
   return (

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -95,7 +95,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
         console.error(error);
       }
     },
-    [validateRoutie],
+    [refetchRoutieData],
   );
 
   useEffect(() => {

--- a/frontend/src/domains/routie/contexts/useRoutieValidateContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieValidateContext.tsx
@@ -7,8 +7,9 @@ import useRoutieValidate, {
 const RoutieValidateContext = createContext<UseRoutieValidateReturn>({
   isValidateActive: true,
   routieTime: {
-    startDateTime: '',
-    endDateTime: '',
+    date: '',
+    startTime: '',
+    endTime: '',
   },
   validationErrors: null,
   validationStatus: 'waiting',
@@ -16,6 +17,10 @@ const RoutieValidateContext = createContext<UseRoutieValidateReturn>({
   handleValidateToggle: () => {},
   handleTimeChange: () => {},
   validateRoutie: async () => {},
+  combineDateTime: {
+    startDateTime: '',
+    endDateTime: '',
+  },
 });
 
 export const RoutieValidateProvider = ({
@@ -32,6 +37,7 @@ export const RoutieValidateProvider = ({
     handleValidateToggle,
     handleTimeChange,
     validateRoutie,
+    combineDateTime,
   } = useRoutieValidate();
 
   const contextValue = useMemo(() => {
@@ -44,6 +50,7 @@ export const RoutieValidateProvider = ({
       handleValidateToggle,
       handleTimeChange,
       validateRoutie,
+      combineDateTime,
     };
   }, [
     isValidateActive,
@@ -54,6 +61,7 @@ export const RoutieValidateProvider = ({
     handleValidateToggle,
     handleTimeChange,
     validateRoutie,
+    combineDateTime,
   ]);
 
   return (

--- a/frontend/src/domains/routie/hooks/useRoutieValidate.ts
+++ b/frontend/src/domains/routie/hooks/useRoutieValidate.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState, useEffect, useMemo } from 'react';
 
+import { useSessionStorage } from '@/@common/hooks/useSessionStorage';
 import { getCombineDateTime } from '@/@common/utils/format';
 
 import { getRoutieValidation } from '../apis/routie';
@@ -40,11 +41,14 @@ const useRoutieValidate = (): UseRoutieValidateReturn => {
   const [isValidateActive, setIsValidateActive] = useState(
     getInitialValidateActive,
   );
-  const [routieTime, setRoutieTime] = useState({
-    date: '',
-    startTime: '',
-    endTime: '',
-  });
+  const [routieTime, setRoutieTime] = useSessionStorage(
+    'routieTime',
+    {
+      date: '',
+      startTime: '',
+      endTime: '',
+    },
+  );
   const [validationErrors, setValidationErrors] =
     useState<validationErrorCodeType | null>(null);
   const [validationStatus, setValidationStatus] =
@@ -123,12 +127,15 @@ const useRoutieValidate = (): UseRoutieValidateReturn => {
     updateValidationStatus();
   }, [isValidateActive, routieTime, updateValidationStatus]);
 
-  const handleTimeChange = useCallback((field: string, value: string) => {
-    setRoutieTime((prev) => ({
-      ...prev,
-      [field]: value,
-    }));
-  }, []);
+  const handleTimeChange = useCallback(
+    (field: string, value: string) => {
+      setRoutieTime({
+        ...routieTime,
+        [field]: value,
+      });
+    },
+    [routieTime, setRoutieTime],
+  );
 
   const validateRoutie = useCallback(
     async (placeCount?: number) => {

--- a/frontend/src/domains/routie/hooks/useRoutieValidate.ts
+++ b/frontend/src/domains/routie/hooks/useRoutieValidate.ts
@@ -33,13 +33,9 @@ export interface UseRoutieValidateReturn {
 }
 
 const useRoutieValidate = (): UseRoutieValidateReturn => {
-  const getInitialValidateActive = () => {
-    const saved = sessionStorage.getItem('isValidateActive');
-    return saved ? JSON.parse(saved) : true;
-  };
-
-  const [isValidateActive, setIsValidateActive] = useState(
-    getInitialValidateActive,
+  const [isValidateActive, setIsValidateActive] = useSessionStorage(
+    'isValidateActive',
+    true,
   );
   const [routieTime, setRoutieTime] = useSessionStorage(
     'routieTime',
@@ -111,13 +107,8 @@ const useRoutieValidate = (): UseRoutieValidateReturn => {
   );
 
   const handleValidateToggle = useCallback(() => {
-    const newIsValidateActive = !isValidateActive;
-    sessionStorage.setItem(
-      'isValidateActive',
-      JSON.stringify(newIsValidateActive),
-    );
-    setIsValidateActive(newIsValidateActive);
-  }, [isValidateActive]);
+    setIsValidateActive(!isValidateActive);
+  }, [isValidateActive, setIsValidateActive]);
 
   const combineDateTime = useMemo(() => {
     return getCombineDateTime(routieTime);

--- a/frontend/src/layouts/Sidebar/DateInput.tsx
+++ b/frontend/src/layouts/Sidebar/DateInput.tsx
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+
+import Flex from '@/@common/components/Flex/Flex';
+import Input from '@/@common/components/Input/Input';
+import { getKoreanCurrentDateISO } from '@/@common/utils/format';
+import { useRoutieValidateContext } from '@/domains/routie/contexts/useRoutieValidateContext';
+
+const DateInput = () => {
+  const { isValidateActive, routieTime, handleTimeChange } =
+    useRoutieValidateContext();
+  const formattedDate = useMemo(() => getKoreanCurrentDateISO(), []);
+
+  return (
+    <Flex direction="column" width="100%" gap={1} alignItems="flex-start">
+      <Input
+        variant={isValidateActive ? 'primary' : 'disabled'}
+        id="date"
+        label="예정 날짜"
+        type="date"
+        value={routieTime.date}
+        min={formattedDate}
+        onChange={(value) => handleTimeChange('date', value)}
+      />
+    </Flex>
+  );
+};
+
+export default DateInput;

--- a/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -19,6 +19,7 @@ import { useGoogleEventTrigger } from '@/libs/googleAnalytics/hooks/useGoogleEve
 
 import { usePlaceListContext } from '../PlaceList/contexts/PlaceListContext';
 
+import DateInput from './DateInput';
 import TimeInput from './TimeInput';
 
 interface SidebarProps {
@@ -31,11 +32,9 @@ const Sidebar = ({ handleViewModeChange }: SidebarProps) => {
   const [addModalOpen, setAddModalOpen] = useState(false);
   const {
     isValidateActive,
-    routieTime,
     validationStatus,
     waitingReason,
     handleValidateToggle,
-    handleTimeChange,
   } = useRoutieValidateContext();
   const { triggerEvent } = useGoogleEventTrigger();
 
@@ -115,7 +114,8 @@ const Sidebar = ({ handleViewModeChange }: SidebarProps) => {
           </Flex>
 
           {renderValidationCard()}
-          <TimeInput time={routieTime} onChange={handleTimeChange} />
+          <DateInput />
+          <TimeInput />
         </Flex>
         <Flex
           direction="column"

--- a/frontend/src/layouts/Sidebar/TimeInput.tsx
+++ b/frontend/src/layouts/Sidebar/TimeInput.tsx
@@ -1,44 +1,38 @@
 import Flex from '@/@common/components/Flex/Flex';
 import Input from '@/@common/components/Input/Input';
-import { getKoreanDateTimeISO } from '@/@common/utils/format';
 import { useRoutieValidateContext } from '@/domains/routie/contexts/useRoutieValidateContext';
 
-const TimeInput = ({
-  time,
-  onChange,
-}: {
-  time: { startDateTime: string; endDateTime: string };
-  onChange: (field: 'startDateTime' | 'endDateTime', value: string) => void;
-}) => {
-  const { isValidateActive } = useRoutieValidateContext();
-  const minimumStartDateTime = getKoreanDateTimeISO(new Date());
+const TimeInput = () => {
+  const { isValidateActive, routieTime, handleTimeChange } =
+    useRoutieValidateContext();
 
-  const scheduleInputVariant = isValidateActive ? 'primary' : 'disabled';
+  const scheduleInputVariant =
+    isValidateActive && routieTime.date !== '' ? 'primary' : 'disabled';
 
   return (
     <Flex justifyContent="space-between" width="100%" gap={1}>
       <Flex direction="column" alignItems="flex-start" gap={1} width="100%">
         <Input
           variant={scheduleInputVariant}
+          disabled={routieTime.date === ''}
           id="startAt"
-          label="시작"
-          type="datetime-local"
-          value={time.startDateTime}
-          min={minimumStartDateTime}
-          onChange={(value) => onChange('startDateTime', value)}
+          label="시작 시간"
+          type="time"
+          value={routieTime.startTime}
+          step="600"
+          onChange={(value) => handleTimeChange('startTime', value)}
         />
       </Flex>
       <Flex direction="column" alignItems="flex-start" gap={1} width="100%">
         <Input
           variant={scheduleInputVariant}
-          disabled={time.startDateTime === ''}
+          disabled={routieTime.date === '' || routieTime.startTime === ''}
           id="endAt"
-          label="종료"
-          type="datetime-local"
-          value={time.endDateTime}
-          min={time.startDateTime ? time.startDateTime : minimumStartDateTime}
-          max={time.startDateTime ? time.startDateTime : minimumStartDateTime}
-          onChange={(value) => onChange('endDateTime', value)}
+          label="종료 시간"
+          type="time"
+          value={routieTime.endTime}
+          step="600"
+          onChange={(value) => handleTimeChange('endTime', value)}
         />
       </Flex>
     </Flex>


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 우리 서비스는 현재 하루에 대한 검증만 진행하는데 시작 & 종료에 날짜를 두 번 입력해야 하는 불편함이 존재했음
- Input 컴포넌트에서 label을 Text 컴포넌트로 설정하지 않았음
- Input의 disabled 색상 & border가 어색하게 느껴짐

## To-Be
<!-- 변경 사항 -->
- 날짜 입력 & 시간 입력을 분리했습니다
- `Input` 컴포넌트에 `label`을 `Text` 컴포넌트를 사용하게 변경했습니다
- `Input` `disabled`일 때 색상 변경과 `border`를 제거했습니다
- 날짜 & 시간 입력을 분리함에 따라 상태 구조가 변경되어 api 요청을 보낼 때 필요한 형식으로 변환한 파생 상태를 추가했습니다 (`combineDateTime`)

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/6350819b-840f-4e41-be4a-71c0d88fb430

## (Optional) Additional Description
- 시간 입력에 대한 예외처리가 불완전하여 아예 제거하였습니다 -> 추후 추가 예정
- 제가 놓친 부분이 있다면 따끔한 리뷰 부탁드립니다~

Closes #502 

