### PR TITLE
feat: Route 계산을 위한 구글 대중교통 API 연결 구현

### DIFF
--- a/backend/spring-routie/.env.example
+++ b/backend/spring-routie/.env.example
@@ -5,3 +5,4 @@ MYSQL_PASSWORD=routie-password-example
 MYSQL_ROOT_PASSWORD=pwd
 DDL_AUTO=create
 KAKAO_API_KEY=kakao-api-key
+GOOGLE_API_KEY=google-api-key

--- a/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
+++ b/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
@@ -28,11 +28,16 @@ public enum ErrorCode {
             "지원하지 않는 이동 전략입니다.",
             HttpStatus.BAD_REQUEST
     ),
-    KAKAO_LOCAL_API_ERROR(
-            "6001", 
-            "외부 장소 검색 서비스에 문제가 발생했습니다.", 
+    GOOGLE_TRANSIT_ROUTE_API_ERROR(
+            "5005",
+            "경로 계산을 위한 외부 API 호출 중 오류가 발생했습니다.",
             HttpStatus.BAD_GATEWAY
-    )
+    ),
+    KAKAO_LOCAL_API_ERROR(
+            "6001",
+            "외부 장소 검색 서비스에 문제가 발생했습니다.",
+            HttpStatus.BAD_GATEWAY
+    ),
     ;
 
     private final String code;

--- a/backend/spring-routie/src/main/java/routie/place/domain/MovingStrategy.java
+++ b/backend/spring-routie/src/main/java/routie/place/domain/MovingStrategy.java
@@ -1,5 +1,6 @@
 package routie.place.domain;
 
 public enum MovingStrategy {
-    DRIVING
+    DRIVING,
+    TRANSIT
 }

--- a/backend/spring-routie/src/main/java/routie/routie/controller/RoutieController.java
+++ b/backend/spring-routie/src/main/java/routie/routie/controller/RoutieController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import routie.place.domain.MovingStrategy;
 import routie.routie.controller.dto.request.RoutiePlaceCreateRequest;
 import routie.routie.controller.dto.request.RoutieUpdateRequest;
 import routie.routie.controller.dto.response.RoutiePlaceCreateResponse;
@@ -43,21 +44,24 @@ public class RoutieController {
     @GetMapping
     public ResponseEntity<RoutieReadResponse> readRoutie(
             @PathVariable final String routieSpaceIdentifier,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) final LocalDateTime startDateTime
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) final LocalDateTime startDateTime,
+            @RequestParam(required = false) final MovingStrategy movingStrategy
     ) {
-        return ResponseEntity.ok(routieService.getRoutie(routieSpaceIdentifier, startDateTime));
+        return ResponseEntity.ok(routieService.getRoutie(routieSpaceIdentifier, startDateTime, movingStrategy));
     }
 
     @GetMapping("/validation")
     public ResponseEntity<RoutieValidationResponse> validateRoutie(
             @PathVariable final String routieSpaceIdentifier,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) final LocalDateTime startDateTime,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) final LocalDateTime endDateTime
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) final LocalDateTime endDateTime,
+            @RequestParam final MovingStrategy movingStrategy
     ) {
         RoutieValidationResponse routieValidationResponse = routieService.validateRoutie(
                 routieSpaceIdentifier,
                 startDateTime,
-                endDateTime
+                endDateTime,
+                movingStrategy
         );
         return ResponseEntity.ok(routieValidationResponse);
     }

--- a/backend/spring-routie/src/main/java/routie/routie/controller/dto/response/RoutieReadResponse.java
+++ b/backend/spring-routie/src/main/java/routie/routie/controller/dto/response/RoutieReadResponse.java
@@ -3,7 +3,6 @@ package routie.routie.controller.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
-import routie.place.domain.MovingStrategy;
 import routie.routie.domain.Routie;
 import routie.routie.domain.RoutiePlace;
 import routie.routie.domain.route.Route;
@@ -53,7 +52,6 @@ public record RoutieReadResponse(
     public record RouteResponse(
             int fromSequence,
             int toSequence,
-            MovingStrategy movingStrategy,
             int duration,
             int distance
     ) {
@@ -62,7 +60,6 @@ public record RoutieReadResponse(
             return new RouteResponse(
                     route.from().getSequence(),
                     route.to().getSequence(),
-                    route.movingStrategy(),
                     route.duration(),
                     route.distance()
             );

--- a/backend/spring-routie/src/main/java/routie/routie/domain/route/Route.java
+++ b/backend/spring-routie/src/main/java/routie/routie/domain/route/Route.java
@@ -1,12 +1,10 @@
 package routie.routie.domain.route;
 
-import routie.place.domain.MovingStrategy;
 import routie.routie.domain.RoutiePlace;
 
 public record Route(
         RoutiePlace from,
         RoutiePlace to,
-        MovingStrategy movingStrategy,
         int duration,
         int distance
 ) {
@@ -14,7 +12,6 @@ public record Route(
     public Route {
         validateOrigin(from);
         validateDestination(to);
-        validateMovingStrategy(movingStrategy);
     }
 
     private void validateOrigin(final RoutiePlace routiePlace) {
@@ -26,12 +23,6 @@ public record Route(
     private void validateDestination(final RoutiePlace routiePlace) {
         if (routiePlace == null) {
             throw new IllegalArgumentException("도착지는 null일 수 없습니다.");
-        }
-    }
-
-    private void validateMovingStrategy(final MovingStrategy movingStrategy) {
-        if (movingStrategy == null) {
-            throw new IllegalArgumentException("이동 전략은 null일 수 없습니다.");
         }
     }
 }

--- a/backend/spring-routie/src/main/java/routie/routie/domain/route/Routes.java
+++ b/backend/spring-routie/src/main/java/routie/routie/domain/route/Routes.java
@@ -78,4 +78,8 @@ public class Routes {
 
         return List.copyOf(orderedRoutiePlaces);
     }
+
+    public boolean isEmpty() {
+        return routes.isEmpty();
+    }
 }

--- a/backend/spring-routie/src/main/java/routie/routie/domain/timeperiod/TimePeriodCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/domain/timeperiod/TimePeriodCalculator.java
@@ -16,13 +16,10 @@ public class TimePeriodCalculator {
             final List<RoutiePlace> routiePlaces
     ) {
         validateRoutes(routes);
+        validateStartDateTime(startDateTime);
         validateRoutiePlaces(routiePlaces);
 
         TimePeriods timePeriods = TimePeriods.empty();
-
-        if (startDateTime == null) {
-            return timePeriods;
-        }
 
         if (routiePlaces.size() == 1) {
             RoutiePlace firstRoutiePlace = routiePlaces.getFirst();
@@ -54,6 +51,12 @@ public class TimePeriodCalculator {
         }
 
         return timePeriods;
+    }
+
+    private void validateStartDateTime(final LocalDateTime startDateTime) {
+        if (startDateTime == null) {
+            throw new IllegalArgumentException("시작 시각은 null일 수 없습니다.");
+        }
     }
 
     private void validateRoutes(final Routes routes) {

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/driving/DrivingRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/driving/DrivingRouteCalculator.java
@@ -35,7 +35,7 @@ public class DrivingRouteCalculator implements RouteCalculator {
         );
         List<SectionResponse> sectionResponses = getRouteResponse(kakaoDrivingRouteApiResponse).sectionResponses();
 
-        return mapToRoutes(routiePlaces, movingStrategy, sectionResponses);
+        return mapToRoutes(routiePlaces, sectionResponses);
     }
 
     private KakaoDrivingRouteApiResponse.RouteResponse getRouteResponse(
@@ -48,7 +48,6 @@ public class DrivingRouteCalculator implements RouteCalculator {
 
     private Routes mapToRoutes(
             final List<RoutiePlace> routiePlaces,
-            final MovingStrategy movingStrategy,
             final List<SectionResponse> sectionResponses
     ) {
         Map<RoutiePlace, Route> routeMap = new HashMap<>();
@@ -56,7 +55,7 @@ public class DrivingRouteCalculator implements RouteCalculator {
             SectionResponse sectionResponse = sectionResponses.get(i);
             RoutiePlace from = routiePlaces.get(i);
             RoutiePlace to = routiePlaces.get(i + 1);
-            Route route = new Route(from, to, movingStrategy, sectionResponse.duration() / 60,
+            Route route = new Route(from, to, sectionResponse.duration() / 60,
                     sectionResponse.distance());
             routeMap.put(from, route);
         }

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
@@ -1,0 +1,63 @@
+package routie.routie.infrastructure.routecalculator.transit;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import routie.exception.BusinessException;
+import routie.exception.ErrorCode;
+import routie.place.domain.MovingStrategy;
+import routie.routie.domain.RoutiePlace;
+import routie.routie.domain.route.Route;
+import routie.routie.domain.route.RouteCalculator;
+import routie.routie.domain.route.Routes;
+import routie.routie.infrastructure.routecalculator.transit.googletransitapi.GoogleTransitRouteApiClient;
+import routie.routie.infrastructure.routecalculator.transit.googletransitapi.GoogleTransitRouteApiRequest;
+import routie.routie.infrastructure.routecalculator.transit.googletransitapi.GoogleTransitRouteApiResponse;
+import routie.routie.infrastructure.routecalculator.transit.googletransitapi.GoogleTransitRouteApiResponse.RouteResponse;
+
+@Component
+@RequiredArgsConstructor
+public class TransitRouteCalculator implements RouteCalculator {
+
+    private final GoogleTransitRouteApiClient googleTransitRouteApiClient;
+
+    @Override
+    public boolean supportsStrategy(final MovingStrategy movingStrategy) {
+        return movingStrategy.equals(MovingStrategy.TRANSIT);
+    }
+
+    @Override
+    public Routes calculateRoutes(final List<RoutiePlace> routiePlaces, final MovingStrategy movingStrategy) {
+        Map<RoutiePlace, Route> routeMap = new HashMap<>();
+        for (int sequence = 0; sequence < routiePlaces.size() - 1; sequence++) {
+            RoutiePlace from = routiePlaces.get(sequence);
+            RoutiePlace to = routiePlaces.get(sequence + 1);
+            GoogleTransitRouteApiResponse googleTransitRouteApiResponse =
+                    googleTransitRouteApiClient.getRoute(GoogleTransitRouteApiRequest.from(from, to));
+
+            RouteResponse routeResponse = googleTransitRouteApiResponse.routeResponses()
+                    .getFirst();
+
+            routeMap.put(
+                    from,
+                    new Route(
+                            from,
+                            to,
+                            parseDurationResponseToInt(routeResponse.duration()),
+                            routeResponse.distance()
+                    )
+            );
+        }
+        return new Routes(routeMap);
+    }
+
+    private int parseDurationResponseToInt(final String durationResponse) {
+        if (durationResponse != null && durationResponse.endsWith("s")) {
+            String secondsOnly = durationResponse.substring(0, durationResponse.length() - 1);
+            return Integer.parseInt(secondsOnly);
+        }
+        throw new BusinessException(ErrorCode.GOOGLE_TRANSIT_ROUTE_API_ERROR);
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/googletransitapi/GoogleTransitRouteApiClient.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/googletransitapi/GoogleTransitRouteApiClient.java
@@ -1,0 +1,18 @@
+package routie.routie.infrastructure.routecalculator.transit.googletransitapi;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.client.RestClient;
+
+@RequiredArgsConstructor
+public class GoogleTransitRouteApiClient {
+
+    private final RestClient restClient;
+
+    public GoogleTransitRouteApiResponse getRoute(final GoogleTransitRouteApiRequest request) {
+        return restClient.post()
+                .uri("/directions/v2:computeRoutes")
+                .body(request)
+                .retrieve()
+                .body(GoogleTransitRouteApiResponse.class);
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/googletransitapi/GoogleTransitRouteApiClientConfig.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/googletransitapi/GoogleTransitRouteApiClientConfig.java
@@ -1,0 +1,78 @@
+package routie.routie.infrastructure.routecalculator.transit.googletransitapi;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
+import routie.exception.BusinessException;
+import routie.exception.ErrorCode;
+
+@Configuration
+@RequiredArgsConstructor
+public class GoogleTransitRouteApiClientConfig {
+
+    private final ObjectMapper objectMapper;
+    @Value("${google.api.key}")
+    private String googleApiKey;
+
+    @Bean
+    public GoogleTransitRouteApiClient googleTransitApiClient() {
+        RestClient restClient = RestClient.builder()
+                .baseUrl("https://routes.googleapis.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .defaultHeader("X-Goog-Api-Key", googleApiKey)
+                .defaultHeader("X-Goog-FieldMask", "routes.distanceMeters,routes.duration")
+                .defaultStatusHandler(new GoogleTransitApiResponseErrorHandler(objectMapper))
+                .build();
+
+        return new GoogleTransitRouteApiClient(restClient);
+    }
+
+    @Slf4j
+    @RequiredArgsConstructor
+    private static class GoogleTransitApiResponseErrorHandler implements ResponseErrorHandler {
+
+        private final ObjectMapper objectMapper;
+
+        @Override
+        public boolean hasError(final ClientHttpResponse response) {
+            try {
+                return response.getStatusCode().is4xxClientError() || response.getStatusCode().is5xxServerError();
+            } catch (final IOException ioException) {
+                throw new BusinessException(ErrorCode.GOOGLE_TRANSIT_ROUTE_API_ERROR);
+            }
+        }
+
+        @Override
+        public void handleError(
+                final URI url,
+                final HttpMethod method,
+                final ClientHttpResponse response
+        ) throws IOException {
+            log.warn(
+                    "Google 길찾기 API 오류 발생: {}",
+                    objectMapper.readValue(response.getBody(), GoogleTransitApiErrorResponse.class)
+            );
+
+            throw new BusinessException(ErrorCode.GOOGLE_TRANSIT_ROUTE_API_ERROR);
+        }
+
+        private record GoogleTransitApiErrorResponse(
+                @JsonProperty("code") String code,
+                @JsonProperty("msg") String message
+        ) {
+        }
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/googletransitapi/GoogleTransitRouteApiRequest.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/googletransitapi/GoogleTransitRouteApiRequest.java
@@ -1,0 +1,46 @@
+package routie.routie.infrastructure.routecalculator.transit.googletransitapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import routie.place.domain.Place;
+import routie.routie.domain.RoutiePlace;
+
+public record GoogleTransitRouteApiRequest(
+        @JsonProperty("origin") CoordinateRequest origin,
+        @JsonProperty("destination") CoordinateRequest destination,
+        @JsonProperty("travelMode") String travelMode
+) {
+    public static GoogleTransitRouteApiRequest from(final RoutiePlace from, final RoutiePlace to) {
+        return new GoogleTransitRouteApiRequest(
+                CoordinateRequest.from(from),
+                CoordinateRequest.from(to),
+                "TRANSIT"
+        );
+    }
+
+    public record CoordinateRequest(
+            @JsonProperty("location") Location location
+    ) {
+        public static CoordinateRequest from(final RoutiePlace routiePlace) {
+            Place place = routiePlace.getPlace();
+            return new CoordinateRequest(
+                    new Location(
+                            new LatLng(
+                                    place.getLongitude(),
+                                    place.getLatitude()
+                            )
+                    )
+            );
+        }
+    }
+
+    public record Location(
+            @JsonProperty("latLng") LatLng latLng
+    ) {
+    }
+
+    public record LatLng(
+            @JsonProperty("longitude") double longitude,
+            @JsonProperty("latitude") double latitude
+    ) {
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/googletransitapi/GoogleTransitRouteApiResponse.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/googletransitapi/GoogleTransitRouteApiResponse.java
@@ -1,0 +1,15 @@
+package routie.routie.infrastructure.routecalculator.transit.googletransitapi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record GoogleTransitRouteApiResponse(
+        @JsonProperty("routes") List<RouteResponse> routeResponses
+) {
+
+    public record RouteResponse(
+            @JsonProperty("duration") String duration,
+            @JsonProperty("distanceMeters") int distance
+    ) {
+    }
+}

--- a/backend/spring-routie/src/main/resources/application.yml
+++ b/backend/spring-routie/src/main/resources/application.yml
@@ -25,3 +25,7 @@ logging:
 kakao:
   api:
     key: ${KAKAO_API_KEY}
+
+google:
+  api:
+    key: ${GOOGLE_API_KEY}

--- a/backend/spring-routie/src/test/java/routie/routie/service/RoutieServiceValidationTest.java
+++ b/backend/spring-routie/src/test/java/routie/routie/service/RoutieServiceValidationTest.java
@@ -20,6 +20,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.transaction.annotation.Transactional;
+import routie.place.domain.MovingStrategy;
 import routie.place.domain.Place;
 import routie.place.domain.PlaceBuilder;
 import routie.place.repository.PlaceRepository;
@@ -111,7 +112,7 @@ class RoutieServiceValidationTest {
 
         // when
         RoutieValidationResponse response = routieService.validateRoutie(
-                routieSpace.getIdentifier(), startTime, endTime
+                routieSpace.getIdentifier(), startTime, endTime, MovingStrategy.DRIVING
         );
 
         // then
@@ -127,7 +128,7 @@ class RoutieServiceValidationTest {
         LocalDateTime endTime = LocalDateTime.of(2025, 7, 29, 11, 0);
 
         RoutieValidationResponse response = routieService.validateRoutie(
-                routieSpace.getIdentifier(), startTime, endTime
+                routieSpace.getIdentifier(), startTime, endTime, MovingStrategy.DRIVING
         );
 
         assertValidationResultIsFalse(response, ValidationStrategy.IS_WITHIN_TOTAL_TIME);
@@ -140,7 +141,7 @@ class RoutieServiceValidationTest {
         LocalDateTime endTime = LocalDateTime.of(2025, 7, 29, 18, 0);
 
         RoutieValidationResponse response = routieService.validateRoutie(
-                routieSpace.getIdentifier(), startTime, endTime
+                routieSpace.getIdentifier(), startTime, endTime, MovingStrategy.DRIVING
         );
 
         assertValidationResultIsFalse(response, ValidationStrategy.IS_WITHIN_OPERATION_HOURS);
@@ -153,7 +154,7 @@ class RoutieServiceValidationTest {
         LocalDateTime endTime = LocalDateTime.of(2025, 7, 28, 18, 0);
 
         RoutieValidationResponse response = routieService.validateRoutie(
-                routieSpace.getIdentifier(), startTime, endTime
+                routieSpace.getIdentifier(), startTime, endTime, MovingStrategy.DRIVING
         );
 
         assertValidationResultIsFalse(response, ValidationStrategy.IS_NOT_CLOSED_DAY);
@@ -166,7 +167,7 @@ class RoutieServiceValidationTest {
         LocalDateTime endTime = LocalDateTime.of(2025, 7, 29, 20, 0);
 
         RoutieValidationResponse response = routieService.validateRoutie(
-                routieSpace.getIdentifier(), startTime, endTime
+                routieSpace.getIdentifier(), startTime, endTime, MovingStrategy.DRIVING
         );
 
         assertValidationResultIsFalse(response, ValidationStrategy.IS_NOT_DURING_BREAKTIME);
@@ -214,7 +215,7 @@ class RoutieServiceValidationTest {
 
         // when
         RoutieValidationResponse response = routieService.validateRoutie(
-                singleRoutieSpace.getIdentifier(), startTime, endTime
+                routieSpace.getIdentifier(), startTime, endTime, MovingStrategy.DRIVING
         );
 
         // then: 총 시간 부족으로 인해 해당 조건만 false여야 함


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
- 루티 조회, 검증에 paramter 추가(movingStrategy)
- 구글 대중교통 API 연결하여 값 반환
  - 세부적으로는 구글 대중교통은 경유지를 포함한 시간 계산이 불가능.
  - 따라서 장소와 장소 사이의 Route 값을 각각 요청하여 합쳐서 반환하는 형태로 구현하였음.
  - 예시) A, B, C 의 Route 계산을 위해 A-B, B-C 에 해당하는 구글 대중교통 API 호출 후 A-B-C로 나열하여 반환

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

## 구글 API 호출 요청, 응답 예시
```
curl -X POST -H 'content-type: application/json' \
-d '{
"origin": {
  "location": {
    "latLng": {
      "latitude": 37.4691,
      "longitude": 126.4505
    }
  }
},
"destination": {
  "location": {
    "latLng": {
      "latitude": 37.579816,
      "longitude": 126.977041
    }
  }
},
"travelMode": "TRANSIT"
}' \
-H 'Content-Type: application/json' \
-H 'X-Goog-Api-Key: 'AIzaSyCafXyhFZ4wLfxwvHjEz2heWv4007aXL58'' \
-H 'X-Goog-FieldMask: routes.distanceMeters,routes.duration' \
'https://routes.googleapis.com/directions/v2:computeRoutes'

{
"routes": [
  {
    "distanceMeters": 68941,
    "duration": "6247s"
  }
]
}
```



Closes #514 
