### PR TITLE
fix: 잘못된 예상 소요 시간 데이터 제거

### DIFF
--- a/frontend/src/domains/routie/components/RoutieValidationResultCard/RoutieValidationResultCard.tsx
+++ b/frontend/src/domains/routie/components/RoutieValidationResultCard/RoutieValidationResultCard.tsx
@@ -27,7 +27,7 @@ const RoutieValidationResultCard = () => {
       <Flex width="100%" gap={1.5} justifyContent="flex-start" height="100%">
         <img src={isValidRoutie ? successIcon : failIcon} alt="available" />
         <Flex direction="column" gap={0.3} alignItems="flex-start">
-          <Text variant="caption">{resultMessage}</Text>
+          <Text variant="subTitle">{resultMessage}</Text>
         </Flex>
       </Flex>
     </Card>

--- a/frontend/src/domains/routie/components/RoutieValidationResultCard/RoutieValidationResultCard.tsx
+++ b/frontend/src/domains/routie/components/RoutieValidationResultCard/RoutieValidationResultCard.tsx
@@ -7,13 +7,7 @@ import successIcon from '@/assets/icons/success.svg';
 import { VALIDATION_RESULT_MESSAGE } from '../../constants/routieValidation';
 import { useRoutieValidateContext } from '../../contexts/useRoutieValidateContext';
 
-interface RoutieValidationResultCardProps {
-  total_time: number;
-}
-
-const RoutieValidationResultCard = ({
-  total_time,
-}: RoutieValidationResultCardProps) => {
+const RoutieValidationResultCard = () => {
   const { validationErrors } = useRoutieValidateContext();
 
   const isValidRoutie = validationErrors === null;
@@ -34,7 +28,6 @@ const RoutieValidationResultCard = ({
         <img src={isValidRoutie ? successIcon : failIcon} alt="available" />
         <Flex direction="column" gap={0.3} alignItems="flex-start">
           <Text variant="caption">{resultMessage}</Text>
-          <Text variant="description">예상 소요 시간: {total_time}분</Text>
         </Flex>
       </Flex>
     </Card>

--- a/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import Button from '@/@common/components/Button/Button';
 import Flex from '@/@common/components/Flex/Flex';
@@ -28,7 +28,7 @@ interface SidebarProps {
 }
 
 const Sidebar = ({ handleViewModeChange }: SidebarProps) => {
-  const { routes, routiePlaces } = useRoutieContext();
+  const { routiePlaces } = useRoutieContext();
   const { refetchPlaceList } = usePlaceListContext();
   const [addModalOpen, setAddModalOpen] = useState(false);
   const {
@@ -38,10 +38,6 @@ const Sidebar = ({ handleViewModeChange }: SidebarProps) => {
     handleValidateToggle,
   } = useRoutieValidateContext();
   const { triggerEvent } = useGoogleEventTrigger();
-
-  const totalMovingTime = useMemo(() => {
-    return routes?.reduce((acc, cur) => acc + cur.duration, 0) ?? 0;
-  }, [routes]);
 
   const openAddModal = () => {
     triggerEvent({
@@ -68,7 +64,7 @@ const Sidebar = ({ handleViewModeChange }: SidebarProps) => {
         return <RoutieValidationLoadingCard />;
       case 'success':
       case 'error':
-        return <RoutieValidationResultCard total_time={totalMovingTime} />;
+        return <RoutieValidationResultCard />;
       case 'inactive':
       default:
         return <RoutieValidationUnavailableCard />;


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
예상 소요 시간에 체류 시간이 포함되지 않았던 문제 발견

## To-Be
<!-- 변경 사항 -->
- 체류 시간을 받을 수 있는 api가 장소 개별 조회 밖에 없어서 백엔드랑 추가 논의 필요
- 잘못된 데이터를 UI에서 보여주는 것은 옳지 않다고 판단해 관련 세부 사항의 합의가 완료되기 전까지 UI에서 제거
- 일정 통과 메시지의 크기를 증가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="476" height="69" alt="image" src="https://github.com/user-attachments/assets/231c04dc-0384-4c05-b77e-6e05dda71be4" />


## (Optional) Additional Description

Closes #540 
