### PR TITLE
feat: 지도 위의 숫자 마커 구현

### DIFF
--- a/frontend/src/domains/maps/components/KakaoMap.styles.ts
+++ b/frontend/src/domains/maps/components/KakaoMap.styles.ts
@@ -36,3 +36,23 @@ export const KakaoMapErrorStyle = css`
 
   background-color: #f8f9fa;
 `;
+
+export const MarkerLabelStyle = css`
+  .marker-label {
+    cursor: pointer;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+
+    font-size: 16px;
+    font-weight: bold;
+    color: white;
+
+    background: #2b6cb0;
+  }
+`;

--- a/frontend/src/domains/maps/components/KakaoMap.tsx
+++ b/frontend/src/domains/maps/components/KakaoMap.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { Global } from '@emotion/react';
 
 import Button from '@/@common/components/Button/Button';
 import Flex from '@/@common/components/Flex/Flex';
@@ -19,6 +20,7 @@ import {
   KakaoMapErrorStyle,
   KakaoMapLoadingStyle,
   KakaoMapWrapperStyle,
+  MarkerLabelStyle,
 } from './KakaoMap.styles';
 import PlaceOverlayCard from './PlaceOverlayCard';
 
@@ -93,8 +95,8 @@ const KakaoMap = ({ lat = 37.554, lng = 126.97, level = 7 }: KakaoMapProps) => {
     const renderMapElements = () => {
       clearMarkers();
 
-      placeList.forEach((place) => {
-        drawMarkers(place.latitude, place.longitude, () => {
+      placeList.forEach((place, index) => {
+        drawMarkers(place.latitude, place.longitude, index + 1, () => {
           setSelectedPlace(place);
           openAt(place.latitude, place.longitude);
           fitMapToMarker(place.latitude, place.longitude);
@@ -115,6 +117,7 @@ const KakaoMap = ({ lat = 37.554, lng = 126.97, level = 7 }: KakaoMapProps) => {
 
   return (
     <div css={KakaoMapWrapperStyle}>
+      <Global styles={MarkerLabelStyle} />
       <div
         ref={mapContainerRef}
         css={KakaoMapContainerStyle}

--- a/frontend/src/domains/maps/hooks/useMapMarker.ts
+++ b/frontend/src/domains/maps/hooks/useMapMarker.ts
@@ -1,6 +1,7 @@
 import { RefObject, useCallback, useRef } from 'react';
 
 import type { KakaoMapType } from '../types/KaKaoMap.types';
+import { MarkerLabelStyle } from '../components/KakaoMap.styles';
 
 type Marker = InstanceType<typeof window.kakao.maps.Marker>;
 
@@ -15,21 +16,29 @@ const useMapMarker = ({ map }: { map: RefObject<KakaoMapType> }) => {
   }, []);
 
   const drawMarkers = useCallback(
-    (lat: number, lng: number, onClick?: () => void) => {
+    (lat: number, lng: number, index: number, onClick?: () => void) => {
       if (!map.current) return;
 
       const position = new window.kakao.maps.LatLng(lat, lng);
-      const marker = new window.kakao.maps.Marker({
+
+      const content = document.createElement('div');
+      content.className = 'marker-label';
+      content.innerText = String(index);
+
+      const overlay = new window.kakao.maps.CustomOverlay({
         position,
+        content,
+        yAnchor: 1,
       });
-      marker.setMap(map.current);
+
+      overlay.setMap(map.current);
 
       if (onClick) {
-        window.kakao.maps.event.addListener(marker, 'click', onClick);
+        content.addEventListener('click', onClick);
       }
 
-      markersRef.current.push(marker);
-      return marker;
+      markersRef.current.push(overlay);
+      return overlay;
     },
     [map],
   );


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
- 기존 지도 핀 마커를 제거하였습니다.
- 경로를 알아보기 쉽게 하기 위해 숫자로 표시하였습니다. 


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

<img width="810" height="711" alt="image" src="https://github.com/user-attachments/assets/d4c7a396-ba5d-4f41-a819-80e1562715b8" />


## (Optional) Additional Description

카카오맵 CustomOverlay는 React JSX를 직접 받을 수 없어 css={{}}를 적용할 수 없었습니다.
이 과정에서 React 컴포넌트를 문자열로 변환하는 react-dom/server의 renderToString을 활용하는 방법도 고려했지만, 불필요한 의존성이 추가되고 구현 복잡도가 높아지는 단점이 있어 적용하지 않았습니다.
대신 DOM을 직접 생성해 className을 부여하는 방식으로 구현했고, 스타일 관리를 위해 Emotion의 <Global />을 사용했습니다.
<Global />은 위치와 상관없이 전역에 적용되므로 <Flex> 내부로 분리할 수도 있지만 실제 동작에는 차이가 없어, 태그 구조를 변경하는 것이 적절한지는 고민되는 부분입니다.
저도 완벽히 이해한 것 같지 않아서 이에 대해 의견 남겨주시면 정말 감사드립니다.. 🙇‍♀️

Closes #458
