### PR TITLE
fix: traceId가 GlobalExceptionHandler까지 가기 전 사라지는 문제 해결

### DIFF
--- a/backend/spring-routie/src/main/java/routie/logging/infrastructure/aspect/RequestLoggingAspect.java
+++ b/backend/spring-routie/src/main/java/routie/logging/infrastructure/aspect/RequestLoggingAspect.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -41,8 +42,15 @@ public class RequestLoggingAspect {
         } finally {
             long executionTime = System.currentTimeMillis() - startTime;
             logClientRequest(joinPoint, httpServletRequest, executionTime, isSuccess);
-            TraceIdHolder.clearTraceId();
+            if (isSuccess) {
+                TraceIdHolder.clearTraceId();
+            }
         }
+    }
+
+    @After("execution(* routie.exception.GlobalExceptionHandler.*(..))")
+    public void cleanupAfterExceptionHandling() {
+        TraceIdHolder.clearTraceId();
     }
 
     private void logClientRequest(


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- traceId가 dev Profile일 때 aop에서 삭제돼 exception 발생 시 기록이 안되는 문제 발견

## To-Be
<!-- 변경 사항 -->
- 실패 상황에서 GlobalException이 종료 후 traceId 삭제

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #555 