### PR TITLE
chore: Spring Actuator 의존성 추가

### DIFF
--- a/backend/spring-routie/build.gradle
+++ b/backend/spring-routie/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/spring-routie/src/main/resources/application.yml
+++ b/backend/spring-routie/src/main/resources/application.yml
@@ -17,6 +17,12 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
     show-sql: true
+    
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
 
 logging:
   file:


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
애플리케이션 헬스 체크가 필요했음.

## To-Be
<!-- 변경 사항 -->
Spring Actuator 를 통한 애플리케이션 헬스 체크 구현.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
Spring Actuator 를 사용하지 않고 /health 와 같은 경로로 커스텀하게 구현할 수 있었음.
그럼에서 Actuator 를 사용한 이유는 추후 헬스 체크를 넘어 애플리케이션의 구동 상태를 편하게 활용할 수 있기 때문.

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
