### PR TITLE
fix: dev 배포에서 msw가 실행되지 않게 수정

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -15,7 +15,7 @@ Sentry.init({
 });
 
 async function enableMocking() {
-  if (process.env.NODE_ENV !== 'development') {
+  if (window.location.hostname !== 'localhost') {
     return;
   }
 


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- dev.routie.me에서 msw가 실행되었는데 public에 있는 mockServiceWorker.js가 빌드시에 포함되지 않아서 에러가 발생함
- 애초에 dev.routie.me에서는 msw를 사용하지 않는 것이 맞다고 판단

## To-Be
<!-- 변경 사항 -->
- msw 실행 조건을 hostname === 'localhost'인 경우에만 실행될 수 있게 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
- 로컬에서 msw를 실행했을 때
<img width="329" height="122" alt="image" src="https://github.com/user-attachments/assets/0ce48a2d-2d1b-477f-a719-3efcb94bb5b2" />

- dev.routie.me에서 실행했을 때
<img width="141" height="124" alt="image" src="https://github.com/user-attachments/assets/8c53f9dc-52f2-4133-881c-571ea13029af" />


## (Optional) Additional Description



Closes #568 
