### PR TITLE
fix: Card에서 정의된 한 줄로 말 줄임 코드를 Text 컴포넌트로 이동하도록 수정

### DIFF
--- a/frontend/src/@common/components/Card/Card.styles.ts
+++ b/frontend/src/@common/components/Card/Card.styles.ts
@@ -43,16 +43,11 @@ const CardStyle = (
   width: string | undefined,
   height: string | undefined,
 ) => css`
-  overflow: hidden;
-
   box-sizing: border-box;
   width: ${width ? width : '100%'};
   height: ${height ? height : 'auto'};
   padding: 1.6rem;
   border-radius: 8px;
-
-  text-overflow: ellipsis;
-  white-space: nowrap;
 
   background-color: ${theme.colors.white};
   ${cardVariant[variant]}

--- a/frontend/src/@common/components/Text/Text.style.ts
+++ b/frontend/src/@common/components/Text/Text.style.ts
@@ -27,9 +27,16 @@ const textVariant: Record<TextVariantProps, SerializedStyles> = {
   `,
 };
 
-export const TextStyle = ({ color, variant }: TextProps) => css`
+export const TextStyle = ({ color, variant, ellipsis }: TextProps) => css`
   box-sizing: border-box;
   max-width: 100%;
   color: ${color ?? theme.colors.black};
   ${variant && textVariant[variant]}
+  ${ellipsis &&
+  css`
+    overflow: hidden;
+    display: block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `}
 `;

--- a/frontend/src/@common/components/Text/Text.types.ts
+++ b/frontend/src/@common/components/Text/Text.types.ts
@@ -3,6 +3,7 @@ import { ComponentProps } from 'react';
 export interface TextProps extends ComponentProps<'p'> {
   color?: string;
   variant: TextVariantProps;
+  ellipsis?: boolean;
 }
 
 export type TextVariantProps =

--- a/frontend/src/domains/maps/components/PlaceOverlayCard.tsx
+++ b/frontend/src/domains/maps/components/PlaceOverlayCard.tsx
@@ -41,8 +41,10 @@ const PlaceOverlayCard = ({ place, onClose }: Props) => {
           <IconButton icon={closeIcon} onClick={onClose} />
         </Flex>
 
-        <Text variant="subTitle">{place.name}</Text>
-        <Text variant="caption" color={theme.colors.gray[200]}>
+        <Text variant="subTitle" ellipsis>
+          {place.name}
+        </Text>
+        <Text variant="caption" color={theme.colors.gray[200]} ellipsis>
           {place.roadAddressName}
         </Text>
         <Pill type="time">

--- a/frontend/src/domains/places/components/PlaceCard/PlaceCard.tsx
+++ b/frontend/src/domains/places/components/PlaceCard/PlaceCard.tsx
@@ -103,26 +103,39 @@ export const PlaceCard = ({ selected, ...props }: PlaceCardProps) => {
                 }
               `}
             />
-            <Flex direction="column" alignItems="flex-start" gap={1}>
-              <Text variant="subTitle">{props.name}</Text>
-              <Text variant="caption" color={theme.colors.gray[200]}>
+            <Flex
+              direction="column"
+              alignItems="flex-start"
+              gap={1}
+              css={css`
+                flex: 1;
+                min-width: 0;
+              `}
+            >
+              <Text variant="subTitle" ellipsis>
+                {props.name}
+              </Text>
+              <Text variant="caption" color={theme.colors.gray[200]} ellipsis>
                 {props.roadAddressName}
               </Text>
               <Flex direction="row" gap={1}>
-                <Text variant="description">영업 시간</Text>
+                <Text variant="description" ellipsis>
+                  영업 시간
+                </Text>
                 <Pill type="time">
                   {props.openAt}-{props.closeAt}
                 </Pill>
               </Flex>
               {props.breakStartAt && (
                 <Flex direction="row" gap={1}>
-                  <Text variant="description">브레이크</Text>
+                  <Text variant="description" ellipsis>
+                    브레이크
+                  </Text>
                   <Pill type="time">
                     {props.breakStartAt}-{props.breakEndAt}
                   </Pill>
                 </Flex>
               )}
-
               <DatePreviewList
                 value={getCheckedListExcept(props.closedDayOfWeeks)}
               />


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
ellipsis를 적용시키기 위해서는 텍스트가 들어있어야하는데, Card는 텍스트를 직접 갖고 있는 게 아니라 안에 Flex → Text 컴포넌트와 같은 구조를 갖고 있었기에 말 줄임이 적용되지 않는 문제를 발견


## To-Be
<!-- 변경 사항 -->
- Card에서 정의된 ellipsis 제거 후 Text에 optional로 추가
- PlaceCard와 PlaceOverlayCard에 적용


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

<img width="798" height="334" alt="image" src="https://github.com/user-attachments/assets/e6f94039-fef6-4fd1-a05b-6a33ffbe9967" />


## (Optional) Additional Description


Closes #569 
