### PR TITLE
chore: release 태그 기반으로 frontend package.json 버전 자동 동기화 워크플로우 추가

### DIFF
--- a/.github/workflows/frontend-sync-version.yml
+++ b/.github/workflows/frontend-sync-version.yml
@@ -1,0 +1,74 @@
+name: Sync package.json version
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sync-version-main:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
+      - name: Update frontend/package.json and package-lock.json
+        run: |
+          jq ".version = \"${VERSION}\"" frontend/package.json > tmp.json
+          mv tmp.json frontend/package.json
+
+          if [ -f frontend/package-lock.json ]; then
+            jq ".version = \"${VERSION}\"" frontend/package-lock.json > tmp-lock.json
+            mv tmp-lock.json frontend/package-lock.json
+          fi
+
+      - name: Create Pull Request to main
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: sync-version/main-${{ env.VERSION }}
+          base: main
+          title: 'chore(main): sync frontend package.json to ${{ env.VERSION }}'
+          body: '자동 생성된 package.json / package-lock.json 버전 동기화 PR (main)'
+          commit-message: 'chore(main): sync frontend package.json to ${{ env.VERSION }}'
+          delete-branch: true
+
+  sync-version-develop:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+
+      - name: Update frontend/package.json and package-lock.json
+        run: |
+          jq ".version = \"${VERSION}\"" frontend/package.json > tmp.json
+          mv tmp.json frontend/package.json
+
+          if [ -f frontend/package-lock.json ]; then
+            jq ".version = \"${VERSION}\"" frontend/package-lock.json > tmp-lock.json
+            mv tmp-lock.json frontend/package-lock.json
+          fi
+
+      - name: Create Pull Request to develop
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: sync-version/develop-${{ env.VERSION }}
+          base: develop
+          title: 'chore(develop): sync frontend package.json to ${{ env.VERSION }}'
+          body: '자동 생성된 package.json / package-lock.json 버전 동기화 PR (develop)'
+          commit-message: 'chore(develop): sync frontend package.json to ${{ env.VERSION }}'
+          delete-branch: true

--- a/.github/workflows/frontend-sync-version.yml
+++ b/.github/workflows/frontend-sync-version.yml
@@ -4,71 +4,76 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  sync-version-main:
+  sync-and-pr:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout full history
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Extract version from tag
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
-      - name: Update frontend/package.json and package-lock.json
+      - name: Set git identity
         run: |
-          jq ".version = \"${VERSION}\"" frontend/package.json > tmp.json
-          mv tmp.json frontend/package.json
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update version on develop (commit & push directly)
+        run: |
+          # ensure we have develop
+          git fetch origin develop:develop
+          git checkout develop
+
+          jq ".version = \"${VERSION}\"" frontend/package.json > tmp.json && mv tmp.json frontend/package.json
 
           if [ -f frontend/package-lock.json ]; then
-            jq ".version = \"${VERSION}\"" frontend/package-lock.json > tmp-lock.json
-            mv tmp-lock.json frontend/package-lock.json
+            jq ".version = \"${VERSION}\"" frontend/package-lock.json > tmp-lock.json && mv tmp-lock.json frontend/package-lock.json
           fi
 
-      - name: Create Pull Request to main
-        uses: peter-evans/create-pull-request@v6
-        with:
-          branch: sync-version/main-${{ env.VERSION }}
-          base: main
-          title: 'chore(main): sync frontend package.json to ${{ env.VERSION }}'
-          body: '자동 생성된 package.json / package-lock.json 버전 동기화 PR (main)'
-          commit-message: 'chore(main): sync frontend package.json to ${{ env.VERSION }}'
-          delete-branch: true
-
-  sync-version-develop:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Extract version from tag
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
-
-      - name: Update frontend/package.json and package-lock.json
-        run: |
-          jq ".version = \"${VERSION}\"" frontend/package.json > tmp.json
-          mv tmp.json frontend/package.json
-
-          if [ -f frontend/package-lock.json ]; then
-            jq ".version = \"${VERSION}\"" frontend/package-lock.json > tmp-lock.json
-            mv tmp-lock.json frontend/package-lock.json
+          if git diff --quiet; then
+            echo "No version changes to commit on develop."
+          else
+            git add frontend/package.json frontend/package-lock.json 2>/dev/null || true
+            git commit -m "chore: frontend package.json(/lock) 버전을 ${VERSION}으로 업데이트"
+            git push origin develop
           fi
 
-      - name: Create Pull Request to develop
-        uses: peter-evans/create-pull-request@v6
+      - name: Open/ensure PR from develop to main
+        uses: actions/github-script@v7
         with:
-          branch: sync-version/develop-${{ env.VERSION }}
-          base: develop
-          title: 'chore(develop): sync frontend package.json to ${{ env.VERSION }}'
-          body: '자동 생성된 package.json / package-lock.json 버전 동기화 PR (develop)'
-          commit-message: 'chore(develop): sync frontend package.json to ${{ env.VERSION }}'
-          delete-branch: true
+          script: |
+            const {owner, repo} = context.repo;
+
+            // Check if an open PR from develop -> main already exists
+            const existing = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', base: 'main', head: `${owner}:develop`
+            });
+
+            if (existing.length > 0) {
+              core.info(`PR already open: #${existing[0].number}`);
+              return;
+            }
+
+            const title = `chore: frontend package.json(/lock) 버전을 ${process.env.VERSION}으로 업데이트`;
+            const body = [
+              `자동 생성: develop의 변경 사항을 main으로 병합하는 PR입니다.`,
+              ``,
+              `- 포함: frontend package.json(/lock) 버전 동기화 → ${process.env.VERSION}`,
+            ].join('\n');
+
+            const res = await github.rest.pulls.create({
+              owner, repo,
+              title,
+              head: 'develop',
+              base: 'main',
+              body
+            });
+            core.info(`Opened PR #${res.data.number}`);


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 만약 main에서 릴리즈를 하면 package.json에 해당 버전이 반영이 안됨

## To-Be
<!-- 변경 사항 -->
- 서비스 릴리스 시점(태그가 생성될 때)마다 `frontend/package.json` 및 `package-lock.json`의 버전을 자동으로 갱신하기 위한 워크플로우를 추가했습니다.  
- 기존에는 수동으로 package.json 버전을 수정해야 했으나, 이제 릴리스 태그만 만들면 자동으로 동기화 PR이 열리게 됩니다.
- main과 develop 브랜치가 항상 동일한 버전 정보를 가지도록 자동화됩니다.
- 릴리스 버전과 frontend 버전이 불일치하는 문제를 예방할 수 있습니다.

## 동작 방식
1. GitHub Release(`release.published`) 이벤트가 발생하면 실행됩니다.
2. 태그명(vX.Y.Z)에서 버전 번호를 추출합니다.
3. `frontend/package.json`과 `frontend/package-lock.json`의 `version` 필드를 해당 버전으로 업데이트합니다.
   - `package-lock.json`이 존재하지 않는 경우 자동으로 무시됩니다.
4. 변경 사항을 포함한 PR을 자동 생성합니다.
   - `main` → `sync-version/main-X.Y.Z`
   - `develop` → `sync-version/develop-X.Y.Z`

## Check List
- [ ] 테스트가 전부 통과되었나요?
- [ ] 모든 commit이 push 되었나요?
- [ ] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
close #580 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to sync the frontend version with published releases.
  * Automatically updates the develop branch with the release version and commits changes when needed.
  * Ensures a pull request from develop to main is opened if one doesn’t already exist.
  * No changes to user-facing functionality; improves release consistency and reduces manual steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->