### PR TITLE
chore: 현재 배포 버전을 확인할 수 있는 페이지 추가

### DIFF
--- a/frontend/src/pages/VersionInfo/VersionInfo.tsx
+++ b/frontend/src/pages/VersionInfo/VersionInfo.tsx
@@ -1,0 +1,33 @@
+import Flex from '@/@common/components/Flex/Flex';
+import Text from '@/@common/components/Text/Text';
+
+const VersionInfo = () => {
+  const commitHash = __COMMIT_HASH__;
+  const buildVersion = __BUILD_VERSION__;
+  const buildDate = __BUILD_DATE__;
+  const buildEnv = process.env.NODE_ENV;
+
+  const githubCommitUrl = `https://github.com/woowacourse-teams/2025-routie/commit/${commitHash}`;
+  const githubReleaseUrl = `https://github.com/woowacourse-teams/2025-routie/releases/tag/v${buildVersion}`;
+
+  return (
+    <Flex direction="column" height="100dvh" gap={1}>
+      <Text variant="title">
+        버전 번호:{' '}
+        <a href={githubReleaseUrl} target="_blank" rel="noopener noreferrer">
+          v{buildVersion}
+        </a>
+      </Text>
+      <Text variant="title">빌드 환경: {buildEnv}</Text>
+      <Text variant="title">빌드 날짜: {buildDate}</Text>
+      <Text variant="title">
+        마지막 커밋 정보:{' '}
+        <a href={githubCommitUrl} target="_blank" rel="noopener noreferrer">
+          {commitHash}
+        </a>
+      </Text>
+    </Flex>
+  );
+};
+
+export default VersionInfo;

--- a/frontend/src/pages/VersionInfo/VersionInfo.tsx
+++ b/frontend/src/pages/VersionInfo/VersionInfo.tsx
@@ -2,30 +2,15 @@ import Flex from '@/@common/components/Flex/Flex';
 import Text from '@/@common/components/Text/Text';
 
 const VersionInfo = () => {
-  const commitHash = __COMMIT_HASH__;
   const buildVersion = __BUILD_VERSION__;
   const buildDate = __BUILD_DATE__;
   const buildEnv = process.env.NODE_ENV;
 
-  const githubCommitUrl = `https://github.com/woowacourse-teams/2025-routie/commit/${commitHash}`;
-  const githubReleaseUrl = `https://github.com/woowacourse-teams/2025-routie/releases/tag/v${buildVersion}`;
-
   return (
     <Flex direction="column" height="100dvh" gap={1}>
-      <Text variant="title">
-        버전 번호:{' '}
-        <a href={githubReleaseUrl} target="_blank" rel="noopener noreferrer">
-          v{buildVersion}
-        </a>
-      </Text>
+      <Text variant="title">버전 번호: v{buildVersion}</Text>
       <Text variant="title">빌드 환경: {buildEnv}</Text>
       <Text variant="title">빌드 날짜: {buildDate}</Text>
-      <Text variant="title">
-        마지막 커밋 정보:{' '}
-        <a href={githubCommitUrl} target="_blank" rel="noopener noreferrer">
-          {commitHash}
-        </a>
-      </Text>
     </Flex>
   );
 };

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -5,6 +5,7 @@ import { ToastProvider } from '@/@common/contexts/useToastContext';
 import { useGoogleAnalytics } from '@/libs/googleAnalytics/hooks/useGoogleAnalytics';
 import Home from '@/pages/Home/Home';
 import RoutieSpace from '@/pages/RoutieSpace/RoutieSpace';
+import VersionInfo from '@/pages/VersionInfo/VersionInfo';
 
 const LayoutWithAnalytics = ({ children }: { children: React.ReactNode }) => {
   useGoogleAnalytics();
@@ -27,6 +28,10 @@ const router = createBrowserRouter([
         <RoutieSpace />
       </LayoutWithAnalytics>
     ),
+  },
+  {
+    path: '/version',
+    element: <VersionInfo />,
   },
 ]);
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,6 +20,7 @@
     "vitest.config.mts",
     "global.d.ts",
     "vitest.setup.ts",
-    "kakao.d.ts"
+    "kakao.d.ts",
+    "version.d.ts"
   ]
 }

--- a/frontend/version.d.ts
+++ b/frontend/version.d.ts
@@ -1,3 +1,2 @@
-declare const __COMMIT_HASH__: string;
 declare const __BUILD_VERSION__: string;
 declare const __BUILD_DATE__: string;

--- a/frontend/version.d.ts
+++ b/frontend/version.d.ts
@@ -1,0 +1,3 @@
+declare const __COMMIT_HASH__: string;
+declare const __BUILD_VERSION__: string;
+declare const __BUILD_DATE__: string;

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,5 +1,10 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { DefinePlugin } = require('webpack');
+const childProcess = require('child_process');
+
+const commitHash = childProcess.execSync('git rev-parse --short HEAD').toString().trim();
+const buildDate = new Date().toISOString();
 
 module.exports = () => {
   return {
@@ -37,6 +42,11 @@ module.exports = () => {
     plugins: [
       new HtmlWebpackPlugin({
         template: 'public/index.html',
+      }),
+      new DefinePlugin({
+        __BUILD_VERSION__: JSON.stringify(require('./package.json').version),
+        __COMMIT_HASH__: JSON.stringify(commitHash),
+        __BUILD_DATE__: JSON.stringify(buildDate),
       }),
     ],
   };


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
현재 배포가 잘 되었는지 확인할 수 있는 방법이
1. CD 파이프 라인에서 배포가 성공했는지 확인하는 로그
2. 배포할 때 Webpack contenthash 때문에 JS/CSS 파일명이 매 빌드마다 달라져서 개발자 도구 -> 소스 에서 파일명 확인으로 반영 여부 체크 가능.

## To-Be
<!-- 변경 사항 -->
여기에 더해서 UI에서 직접 /version 열어서 → 버전/커밋/빌드 환경 눈으로 확인할 수 있도록 했습니다.
페이지로 배포 버전을 노출한 이유는, 배포 이후 실제 서비스에 최신 버전이 반영됐는지 빠르게 확인하기 위해서입니다.

지금까지는 배포가 잘 되었는지 확인하려면 소스를 확인하던지 파이프라인이 정상적으로 돌았는지 확인하는 과정을 거쳐야 했는데, 이제는 화면에 찍힌 버전 번호만 보면 즉시 알 수 있게 되었습니다.

만약 문제가 생기면, 사용자가 보고 있는 화면이 어느 버전인지 바로 알 수 있어서 장애 대응 시에도 훨씬 빠르게 원인 추적이 가능해질 것 같습니다.

버전 정보는 main에 앞으로 배포할 때마다 release 를 통해서 버전을 생성하면 -> package.json의 버전도 함께 올라가고 배포된 페이지에서는 해당 버전이 보입니다.
<img width="401" height="255" alt="image" src="https://github.com/user-attachments/assets/afab603b-6fcf-4034-a66e-23816348720c" />

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

<img width="1356" height="1048" alt="image" src="https://github.com/user-attachments/assets/49ca7cea-a0ea-46f9-8562-bd7b60c925e1" />
## (Optional) Additional Description

만들어 놓고 보니까 귀찮긴 하지만 배포 되었는지 다른 방법으로 확인해도 되는데 괜히 만든 것 같기도 하네요... 그래도 배포된 페이지에서 간단하게 확인할 수 있는것이 장점인 것 같습니다...
진짜 불필요하다고 생각이 들면 시원하게 말씀해주세요
바로 삭제하겠습니다 ㅎㅎ

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
close #582 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Version Info page at /version showing the app version, build environment, and build date.

* **Chores**
  * Embedded build metadata into the app to support the Version Info display.
  * Added typing support for build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->