### PR TITLE
feat: 루티 조회 쿼리에 이동 수단 추가 및 invalid place 표시 로직 적용

### DIFF
--- a/frontend/src/domains/routie/apis/routie.ts
+++ b/frontend/src/domains/routie/apis/routie.ts
@@ -26,7 +26,6 @@ export const getRoutie = async (
   }
 
   const query = queryParams.toString() ? `?${queryParams.toString()}` : '';
-  console.log(query);
 
   const response = await apiClient.get(
     `/routie-spaces/${routieSpaceUuid}/routie${query}`,

--- a/frontend/src/domains/routie/apis/routie.ts
+++ b/frontend/src/domains/routie/apis/routie.ts
@@ -7,6 +7,7 @@ import { Routie, RoutieValidationResponseType } from '../types/routie.types';
 export const getRoutie = async (
   isValidateActive: boolean,
   routieTime: string,
+  movingStrategy: string,
 ) => {
   const routieSpaceUuid = localStorage.getItem('routieSpaceUuid');
 
@@ -14,8 +15,18 @@ export const getRoutie = async (
     throw new Error('루티 스페이스 uuid가 없습니다.');
   }
 
-  const query =
-    isValidateActive && routieTime ? `?startDateTime=${routieTime}` : '';
+  const queryParams = new URLSearchParams();
+
+  if (isValidateActive && routieTime) {
+    queryParams.append('startDateTime', routieTime);
+  }
+
+  if (movingStrategy) {
+    queryParams.append('movingStrategy', movingStrategy);
+  }
+
+  const query = queryParams.toString() ? `?${queryParams.toString()}` : '';
+  console.log(query);
 
   const response = await apiClient.get(
     `/routie-spaces/${routieSpaceUuid}/routie${query}`,

--- a/frontend/src/domains/routie/components/RoutiePlaceCard/RoutiePlaceCard.tsx
+++ b/frontend/src/domains/routie/components/RoutiePlaceCard/RoutiePlaceCard.tsx
@@ -16,6 +16,7 @@ import theme from '@/styles/theme';
 
 import { getDetailPlace } from '../../apis/routie';
 import { useRoutieContext } from '../../contexts/useRoutieContext';
+import { useRoutieValidateContext } from '../../contexts/useRoutieValidateContext';
 import { Routie } from '../../types/routie.types';
 import formatMinutesToHours from '../../utils/formatMinutesToHours';
 import DraggableWrapper from '../DraggableWrapper/DraggableWrapper';
@@ -63,10 +64,19 @@ const RoutiePlaceCard = ({ routie }: { routie: Routie }) => {
   const checkedListExcept = getCheckedListExcept(place.closedDayOfWeeks);
   const checkedDaysInKorean = getCheckedDaysInKorean(checkedListExcept);
 
+  const { currentInvalidRoutiePlaces } = useRoutieValidateContext();
+
+  const isUnavailable = currentInvalidRoutiePlaces.some(
+    (invalid) => invalid.routiePlaceId === routie.placeId,
+  );
+
   return (
     place && (
       <DraggableWrapper>
-        <Card id={routie.placeId.toString()} variant="defaultStatic">
+        <Card
+          id={routie.placeId.toString()}
+          variant={isUnavailable ? 'unavailable' : 'defaultStatic'}
+        >
           <Flex justifyContent="flex-start" gap={1.5}>
             <Flex width="100%" justifyContent="space-between" gap={1.5}>
               <Flex padding={1}>

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -65,7 +65,11 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
       setRoutes(routies.routes);
       validateRoutie(movingStrategy, routies.routiePlaces.length);
     } catch (error) {
-      console.error('루티 정보를 불러오는데 실패했습니다.', error);
+      console.error(error);
+      showToast({
+        message: '동선 정보를 불러오는데 실패했습니다. 다시 시도해주세요.',
+        type: 'error',
+      });
     }
   }, [
     isValidateActive,
@@ -126,6 +130,10 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
         refetchRoutieData();
       } catch (error) {
         console.error(error);
+        showToast({
+          message: '순서 변경에 실패했습니다.',
+          type: 'error',
+        });
       }
     },
     [refetchRoutieData],

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -59,6 +59,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
       const routies = await getRoutie(
         isValidateActive,
         combineDateTime.startDateTime,
+        movingStrategy,
       );
       setRoutiePlaces(routies.routiePlaces);
       setRoutes(routies.routes);


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 루티 조회 API 명세가 쿼리에 이동수단이 추가됨
-  검증에서 invalid routiePlace를 구분하기 어려워 UI 상에서 표시가 필요

## To-Be
<!-- 변경 사항 -->
- getRoutie API 호출 시 movingStrategy 쿼리 파라미터 추가
- RoutiePlaceCard에서 invalid routiePlace일 경우 Card variant를 'unavailable'로 표시

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="757" height="1275" alt="image" src="https://github.com/user-attachments/assets/20104686-0d20-4b26-816a-0119fddc6f37" />


## (Optional) Additional Description
일단 msw 를 이용해서 명세 그대로 구현 완료했습니다.

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
close #587 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route results now adapt to the selected moving strategy, and data refreshes automatically when the strategy changes.
  * Place cards display an “unavailable” state for locations that can’t be used, improving visibility during validation.
  * Clearer error notifications are shown if loading route information or changing the order fails, with guidance to retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->