### PR TITLE
fix: 대중교통 루티 조회 시작 시간이 없을 시에 현재 시각을 기반으로 계산하도록 수정

### DIFF
--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
@@ -37,7 +37,7 @@ public class TransitRouteCalculator implements RouteCalculator {
     public Routes calculateRoutes(final RouteCalculationContext routeCalculationContext) {
         List<RoutiePlace> routiePlaces = routeCalculationContext.getRoutiePlaces();
         LocalDateTime startDateTime = routeCalculationContext.getStartDateTime()
-                .orElseThrow(() -> new IllegalArgumentException("대중교통 Route 계산에서 startDateTime은 null이 될 수 없습니다."));
+                .orElse(LocalDateTime.now());
 
         validateStartDateTime(startDateTime);
 

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
@@ -56,7 +56,7 @@ public class TransitRouteCalculator implements RouteCalculator {
                     new Route(
                             from,
                             to,
-                            parseDurationResponseToInt(routeResponse.duration()),
+                            parseDurationResponseToInt(routeResponse.duration()) / 60,
                             routeResponse.distance()
                     )
             );

--- a/backend/spring-routie/src/test/java/routie/routie/controller/RoutieControllerTest.java
+++ b/backend/spring-routie/src/test/java/routie/routie/controller/RoutieControllerTest.java
@@ -405,7 +405,7 @@ class RoutieControllerTest {
         RoutieReadResponse routieReadResponse = RestAssured
                 .given().log().all()
                 .when()
-                .queryParam("movingStrategy", "TRANSIT")
+                .queryParam("movingStrategy", "DRIVING")
                 .get("/routie-spaces/" + routieSpace.getIdentifier() + "/routie")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())

--- a/backend/spring-routie/src/test/java/routie/routie/controller/RoutieControllerTest.java
+++ b/backend/spring-routie/src/test/java/routie/routie/controller/RoutieControllerTest.java
@@ -405,7 +405,7 @@ class RoutieControllerTest {
         RoutieReadResponse routieReadResponse = RestAssured
                 .given().log().all()
                 .when()
-                .queryParam("movingStrategy", "DRIVING")
+                .queryParam("movingStrategy", "TRANSIT")
                 .get("/routie-spaces/" + routieSpace.getIdentifier() + "/routie")
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 루티 조회 시 시작 시간이 없는 경우 에러 반환
- 이동 시간을 초로 응답

## To-Be
<!-- 변경 사항 -->
- 루티 조회 시 시작 시간이 없는 경우 현재 시각을 기반으로 계산
- 이동 시간을 분으로 응답하도록 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description



Closes #603 
