### PR TITLE
fix: null로 오는 google 응답 핸들링

### DIFF
--- a/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
+++ b/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
@@ -248,7 +248,7 @@ public enum ErrorCode {
     ),
     ROUTIE_START_TIME_NULL(
             "3023",
-            "일정 시간 시간은 null일 수 없습니다.",
+            "일정 시작 시간은 null일 수 없습니다.",
             HttpStatus.BAD_REQUEST
     ),
     ROUTIE_END_TIME_NULL(
@@ -270,12 +270,12 @@ public enum ErrorCode {
     // TimePeriod Validation
     TIME_PERIOD_START_TIME_NULL(
             "3030",
-            "장소 도착 시간은 null일 수 없습니다.",
+            "장소 시작 시간은 null일 수 없습니다.",
             HttpStatus.BAD_REQUEST
     ),
     TIME_PERIOD_END_TIME_NULL(
             "3031",
-            "장소 출발 시간은 null일 수 없습니다.",
+            "장소 도착 시간은 null일 수 없습니다.",
             HttpStatus.BAD_REQUEST
     ),
     TIME_PERIODS_NULL(

--- a/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
+++ b/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
@@ -261,6 +261,11 @@ public enum ErrorCode {
             "TimePeriods는 null일 수 없습니다.",
             HttpStatus.BAD_REQUEST
     ),
+    ROUTIE_END_TIME_BEFORE_START_TIME(
+            "3026",
+            "일정 종료 시간은 시작 시간보다 빠를 수 없습니다.",
+            HttpStatus.BAD_REQUEST
+    ),
 
     // TimePeriod Validation
     TIME_PERIOD_START_TIME_NULL(

--- a/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
+++ b/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
@@ -314,6 +314,11 @@ public enum ErrorCode {
             "경로 계산을 위한 외부 API 호출 중 오류가 발생했습니다.",
             HttpStatus.BAD_GATEWAY
     ),
+    GOOGLE_TRANSIT_ROUTE_API_DEPARTURE_TIME_OUT_OF_RANGE(
+            "9002",
+            "대중교통 Route 계산 시작 시간은 현재로부터 과거 7일부터 미래 100일 사이여야 합니다.",
+            HttpStatus.BAD_REQUEST
+    ),
     KAKAO_DRIVING_ROUTE_API_RESPONSE_EMPTY(
             "9010",
             "경로 계산을 위한 외부 API 응답이 비어 있습니다.",

--- a/backend/spring-routie/src/main/java/routie/place/domain/Place.java
+++ b/backend/spring-routie/src/main/java/routie/place/domain/Place.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -267,5 +268,10 @@ public class Place {
         if (breakStartAt.isBefore(openAt) || breakEndAt.isAfter(closeAt)) {
             throw new BusinessException(ErrorCode.PLACE_BREAK_TIME_OUTSIDE_BUSINESS_HOURS);
         }
+    }
+
+    public boolean hasSameCoordinate(final Place otherPlace) {
+        return Objects.equals(otherPlace.getLatitude(), latitude)
+                && Objects.equals(otherPlace.getLongitude(), longitude);
     }
 }

--- a/backend/spring-routie/src/main/java/routie/routie/domain/routievalidator/ValidationContext.java
+++ b/backend/spring-routie/src/main/java/routie/routie/domain/routievalidator/ValidationContext.java
@@ -15,6 +15,7 @@ public record ValidationContext(
         validateStartDateTime(startDateTime);
         validateEndDateTime(endDateTime);
         validateTimePeriods(timePeriods);
+        validateTimeOrder(startDateTime, endDateTime);
     }
 
     private void validateStartDateTime(final LocalDateTime startDateTime) {
@@ -32,6 +33,12 @@ public record ValidationContext(
     private void validateTimePeriods(final TimePeriods timePeriods) {
         if (timePeriods == null) {
             throw new BusinessException(ErrorCode.ROUTIE_TIME_PERIODS_NULL);
+        }
+    }
+
+    private void validateTimeOrder(final LocalDateTime startDateTime, final LocalDateTime endDateTime) {
+        if (endDateTime.isBefore(startDateTime)) {
+            throw new BusinessException(ErrorCode.ROUTIE_END_TIME_BEFORE_START_TIME);
         }
     }
 }

--- a/backend/spring-routie/src/main/java/routie/routie/domain/timeperiod/TimePeriodCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/domain/timeperiod/TimePeriodCalculator.java
@@ -57,7 +57,7 @@ public class TimePeriodCalculator {
 
     private void validateStartDateTime(final LocalDateTime startDateTime) {
         if (startDateTime == null) {
-            throw new IllegalArgumentException("시작 시각은 null일 수 없습니다.");
+            throw new BusinessException(ErrorCode.TIME_PERIOD_START_TIME_NULL);
         }
     }
 

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/driving/DrivingRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/driving/DrivingRouteCalculator.java
@@ -47,8 +47,11 @@ public class DrivingRouteCalculator implements RouteCalculator {
         return mapToRoutes(routiePlaces, sectionResponses);
     }
 
-    private boolean isZeroDistanceRoute(final List<RoutiePlace> routiePlaces, final RoutiePlace from,
-                                        final RoutiePlace to) {
+    private boolean isZeroDistanceRoute(
+            final List<RoutiePlace> routiePlaces,
+            final RoutiePlace from,
+            final RoutiePlace to
+    ) {
         return routiePlaces.size() == 2 && from.getPlace().hasSameCoordinate(to.getPlace());
     }
 

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/driving/DrivingRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/driving/DrivingRouteCalculator.java
@@ -32,12 +32,24 @@ public class DrivingRouteCalculator implements RouteCalculator {
     @Override
     public Routes calculateRoutes(final RouteCalculationContext routeCalculationContext) {
         List<RoutiePlace> routiePlaces = routeCalculationContext.getRoutiePlaces();
+
+        RoutiePlace from = routiePlaces.getFirst();
+        RoutiePlace to = routiePlaces.getLast();
+        if (isZeroDistanceRoute(routiePlaces, from, to)) {
+            return new Routes(Map.of(from, new Route(from, to, 0, 0)));
+        }
+
         KakaoDrivingRouteApiResponse kakaoDrivingRouteApiResponse = kakaoDrivingRouteApiClient.getRoute(
                 KakaoDrivingRouteApiRequest.from(routiePlaces)
         );
         List<SectionResponse> sectionResponses = getRouteResponse(kakaoDrivingRouteApiResponse).sectionResponses();
 
         return mapToRoutes(routiePlaces, sectionResponses);
+    }
+
+    private boolean isZeroDistanceRoute(final List<RoutiePlace> routiePlaces, final RoutiePlace from,
+                                        final RoutiePlace to) {
+        return routiePlaces.size() == 2 && from.getPlace().hasSameCoordinate(to.getPlace());
     }
 
     private KakaoDrivingRouteApiResponse.RouteResponse getRouteResponse(

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/driving/DrivingRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/driving/DrivingRouteCalculator.java
@@ -72,8 +72,10 @@ public class DrivingRouteCalculator implements RouteCalculator {
             SectionResponse sectionResponse = sectionResponses.get(i);
             RoutiePlace from = routiePlaces.get(i);
             RoutiePlace to = routiePlaces.get(i + 1);
-            Route route = new Route(from, to, sectionResponse.duration() / 60,
-                    sectionResponse.distance());
+            Route route = new Route(
+                    from, to, sectionResponse.duration() / 60,
+                    sectionResponse.distance()
+            );
             routeMap.put(from, route);
         }
         return new Routes(routeMap);

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
@@ -46,7 +46,7 @@ public class TransitRouteCalculator implements RouteCalculator {
             RoutiePlace from = routiePlaces.get(sequence);
             RoutiePlace to = routiePlaces.get(sequence + 1);
 
-            if (from.getPlace().hasSameCoordinate(to.getPlace())) {
+            if (isZeroDistanceRoute(from, to)) {
                 routeMap.put(from, new Route(from, to, 0, 0));
                 continue;
             }
@@ -68,6 +68,10 @@ public class TransitRouteCalculator implements RouteCalculator {
             );
         }
         return new Routes(routeMap);
+    }
+
+    private boolean isZeroDistanceRoute(final RoutiePlace from, final RoutiePlace to) {
+        return from.getPlace().hasSameCoordinate(to.getPlace());
     }
 
     /**

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
@@ -45,6 +45,12 @@ public class TransitRouteCalculator implements RouteCalculator {
         for (int sequence = 0; sequence < routiePlaces.size() - 1; sequence++) {
             RoutiePlace from = routiePlaces.get(sequence);
             RoutiePlace to = routiePlaces.get(sequence + 1);
+
+            if (from.getPlace().hasSameCoordinate(to.getPlace())) {
+                routeMap.put(from, new Route(from, to, 0, 0));
+                continue;
+            }
+
             GoogleTransitRouteApiResponse googleTransitRouteApiResponse =
                     googleTransitRouteApiClient.getRoute(GoogleTransitRouteApiRequest.from(startDateTime, from, to));
 

--- a/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
+++ b/backend/spring-routie/src/main/java/routie/routie/infrastructure/routecalculator/transit/TransitRouteCalculator.java
@@ -75,7 +75,7 @@ public class TransitRouteCalculator implements RouteCalculator {
         LocalDateTime latestAllowed = now.plusDays(FUTURE_DAYS_LIMIT);
 
         if (startDateTime.isBefore(earliestAllowed) || startDateTime.isAfter(latestAllowed)) {
-            throw new IllegalArgumentException("대중교통 Route 계산 시작 시간은 현재로부터 과거 7일부터 미래 100일 사이여야 합니다.");
+            throw new BusinessException(ErrorCode.GOOGLE_TRANSIT_ROUTE_API_DEPARTURE_TIME_OUT_OF_RANGE);
         }
     }
 

--- a/backend/spring-routie/src/main/java/routie/routie/service/RoutieService.java
+++ b/backend/spring-routie/src/main/java/routie/routie/service/RoutieService.java
@@ -159,12 +159,7 @@ public class RoutieService {
         Routie routie = getRoutieSpaceByIdentifier(routieSpaceIdentifier).getRoutie();
         List<RoutiePlace> routiePlaces = routie.getRoutiePlaces();
         Routes routes = getRoutes(startDateTime, routiePlaces, movingStrategy);
-
-        TimePeriods timePeriods = timePeriodCalculator.calculateTimePeriods(
-                startDateTime,
-                routes,
-                routiePlaces
-        );
+        TimePeriods timePeriods = timePeriodCalculator.calculateTimePeriods(startDateTime, routes, routiePlaces);
 
         ValidationContext validationContext = new ValidationContext(startDateTime, endDateTime, timePeriods);
         List<ValidationResult> validationResults = new ArrayList<>();


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 동일한 위경도의 장소를 가진 루티에 대한 조회가 에러를 발생시켰음
- 카카오 API: 2개 장소를 가진 루티에서 출발지와 목적지가 같은 경우 에러 발생

## To-Be
<!-- 변경 사항 -->
- 카카오 API: 출발지와 목적지가 같은 2개의 장소에 대한 경로를 만드는 경우 -> distance, duration 0으로 응답
- 구글 API: 출발지와 목적지가 같은 경로를 만드는 경우 -> distance, duration 0으로 응답
- 일정 시작 시각이 종료 시작보다 큰 경우, 에러를 반환하도록 수정 

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

Closes #619 
