### PR TITLE
refactor: 사이드바 & 시트 외곽선 적용

### DIFF
--- a/frontend/src/layouts/SideSheet/SideSheet.styles.ts
+++ b/frontend/src/layouts/SideSheet/SideSheet.styles.ts
@@ -13,6 +13,7 @@ export const SheetBaseStyle = css`
 
   width: 40rem;
   min-height: 0;
+  border: 1px solid black;
   border-radius: 12px;
 
   background: ${theme.colors.white};
@@ -45,7 +46,7 @@ export const TabBaseStyle = css`
 
   position: absolute;
   top: 50%;
-  right: -1.8rem;
+  right: -2.5rem;
   transform: translateY(-50%);
 
   display: flex;

--- a/frontend/src/layouts/SideSheet/SideSheet.styles.ts
+++ b/frontend/src/layouts/SideSheet/SideSheet.styles.ts
@@ -13,7 +13,7 @@ export const SheetBaseStyle = css`
 
   width: 40rem;
   min-height: 0;
-  border: 1px solid black;
+  border: 1px solid ${theme.colors.black};
   border-radius: 12px;
 
   background: ${theme.colors.white};

--- a/frontend/src/layouts/SideSheet/SideSheet.tsx
+++ b/frontend/src/layouts/SideSheet/SideSheet.tsx
@@ -73,7 +73,9 @@ const SideSheet = ({ open, onToggle }: SideSheetProps) => {
           alignItems="center"
           justifyContent="space-between"
           width="100%"
-          padding={2}
+          css={css`
+            padding: 0 1rem 2rem;
+          `}
         >
           <Text
             variant="title"
@@ -106,7 +108,12 @@ const SideSheet = ({ open, onToggle }: SideSheetProps) => {
         />
         <div css={SheetListWrapperStyle}>
           <div css={SheetScrollableAreaStyle}>
-            <Flex direction='column' justifyContent='flex-start' gap={1} css={{ overflowY: 'visible' }}>
+            <Flex
+              direction="column"
+              justifyContent="flex-start"
+              gap={1}
+              css={{ overflowY: 'visible' }}
+            >
               {placeList.map((place) => {
                 const selected = routieIdList.includes(place.id);
                 return (

--- a/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import SelectMovingStrategy from '@/domains/routie/components/SelectMovingStrate
 import { useRoutieContext } from '@/domains/routie/contexts/useRoutieContext';
 import { useRoutieValidateContext } from '@/domains/routie/contexts/useRoutieValidateContext';
 import RoutieSpaceName from '@/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName';
+import theme from '@/styles/theme';
 
 import DateInput from './DateInput';
 import TimeInput from './TimeInput';
@@ -55,7 +56,7 @@ const Sidebar = () => {
         gap={1}
         style={{
           overflow: 'hidden',
-          borderRight: '1px solid black',
+          borderRight: `1px solid ${theme.colors.black}`,
         }}
       >
         <Header />

--- a/frontend/src/layouts/Sidebar/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar/Sidebar.tsx
@@ -55,6 +55,7 @@ const Sidebar = () => {
         gap={1}
         style={{
           overflow: 'hidden',
+          borderRight: '1px solid black',
         }}
       >
         <Header />


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
- 사이드 시트 border 추가
- 사이드 시트 css(장소목록, tabBaseStyle) 수정
- 사이드바 border 추가


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

| 닫힌 사이드 시트 | 열린 사이드 시트 |
|----------|----------|
| <img width="561" height="900" alt="스크린샷 2025-08-19 오후 6 24 37" src="https://github.com/user-attachments/assets/4b3d1276-dda7-4a8c-b07f-adc63a0182c5" /> | <img width="942" height="900" alt="image" src="https://github.com/user-attachments/assets/fff255ac-21f7-4359-8425-2b154f9c8063" /> |

## (Optional) Additional Description

Closes #624 
