### PR TITLE
fix: 장소 검색 API에서 도로명 주소 검색 결과가 없는 경우, 빈 문자열이 아닌 null을 응답하도록 수정

### DIFF
--- a/backend/spring-routie/src/main/java/routie/place/controller/dto/response/SearchedPlacesResponse.java
+++ b/backend/spring-routie/src/main/java/routie/place/controller/dto/response/SearchedPlacesResponse.java
@@ -28,7 +28,7 @@ public record SearchedPlacesResponse(
             return new SearchedPlaceResponse(
                     searchedPlace.searchedPlaceId(),
                     searchedPlace.name(),
-                    searchedPlace.roadAddressName().isEmpty() ? null : searchedPlace.roadAddressName(),
+                    searchedPlace.roadAddressName(),
                     searchedPlace.addressName(),
                     searchedPlace.longitude(),
                     searchedPlace.latitude()

--- a/backend/spring-routie/src/main/java/routie/place/domain/SearchedPlace.java
+++ b/backend/spring-routie/src/main/java/routie/place/domain/SearchedPlace.java
@@ -18,6 +18,10 @@ public record SearchedPlace(
         validateAddressName(addressName);
         validateLongitude(longitude);
         validateLatitude(latitude);
+
+        if (roadAddressName.isEmpty()) {
+            roadAddressName = null;
+        }
     }
 
     private void validateSearchedPlaceId(final String searchedPlaceId) {


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 카카오 API에서 장소 검색 결과의 도로명 주소 필드 값이 빈 문자열("")인 경우, 장소 검색 API에서 빈 문자열 그대로 응답하는 중

## To-Be
<!-- 변경 사항 -->
- 카카오 API에서 장소 검색 결과의 도로명 주소 필드 값이 빈 문자열인 경우, 장소 검색 API에서 존재하지 않음을 의미하는 null로 응답하도록 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #639 