### PR TITLE
refactor: 장소를 추가하는 상황 & 마커를 클릭한 경우만 지도 이동

### DIFF
--- a/frontend/src/domains/maps/components/KakaoMap.tsx
+++ b/frontend/src/domains/maps/components/KakaoMap.tsx
@@ -23,7 +23,7 @@ import PlaceOverlayCard from './PlaceOverlayCard';
 
 const KakaoMap = () => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
-  const { placeList } = usePlaceListContext();
+  const { placeList, newlyAddedPlace } = usePlaceListContext();
   const { routieIdList } = useRoutieContext();
   const [isInitialLoad, setIsInitialLoad] = useState(true);
 
@@ -42,9 +42,10 @@ const KakaoMap = () => {
     containerRef: mapContainerRef,
     sdkReady,
   });
-  const { fitMapToMarkers, drawMarkers, clearMarkers } = useMapMarker({
-    map: mapRef,
-  });
+  const { fitMapToMarkers, drawMarkers, clearMarkers, fitMapToMarker } =
+    useMapMarker({
+      map: mapRef,
+    });
   const { loadPolyline, clearPolyline } = usePolyline({
     map: mapRef,
   });
@@ -103,6 +104,9 @@ const KakaoMap = () => {
       if (isInitialLoad && placeList.length > 0) {
         fitMapToMarkers(placeList);
         setIsInitialLoad(false);
+      } else if (newlyAddedPlace) {
+        fitMapToMarker(newlyAddedPlace.latitude, newlyAddedPlace.longitude);
+      }
 
       clearPolyline();
 
@@ -112,7 +116,7 @@ const KakaoMap = () => {
     };
 
     renderMapElements();
-  }, [mapState, placeList, routiePlaces]);
+  }, [mapState, placeList, routiePlaces, newlyAddedPlace]);
 
   return (
     <div css={KakaoMapWrapperStyle}>

--- a/frontend/src/domains/maps/components/KakaoMap.tsx
+++ b/frontend/src/domains/maps/components/KakaoMap.tsx
@@ -25,6 +25,7 @@ const KakaoMap = () => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const { placeList } = usePlaceListContext();
   const { routieIdList } = useRoutieContext();
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
 
   const routiePlaces = useMemo(
     () =>
@@ -99,7 +100,9 @@ const KakaoMap = () => {
         });
       });
 
-      fitMapToMarkers(placeList);
+      if (isInitialLoad && placeList.length > 0) {
+        fitMapToMarkers(placeList);
+        setIsInitialLoad(false);
 
       clearPolyline();
 

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
@@ -18,15 +18,7 @@ import AddPlaceModalButtons from './AddPlaceModalButtons';
 import AddPlaceModalHeader from './AddPlaceModalHeader';
 import AddPlaceValidation from './AddPlaceValidation';
 
-interface AddPlaceModalProps extends Omit<ModalProps, 'children'> {
-  onPlaceAdded?: () => Promise<void>;
-}
-
-const AddPlaceModal = ({
-  isOpen,
-  onClose,
-  onPlaceAdded,
-}: AddPlaceModalProps) => {
+const AddPlaceModal = ({ isOpen, onClose }: Omit<ModalProps, 'children'>) => {
   const { form, handleInputChange, handleToggleDay, resetForm } =
     useAddPlaceForm();
   const { isEmpty, isValid } = usePlaceFormValidation(form);

--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceModal.tsx
@@ -6,6 +6,7 @@ import Text from '@/@common/components/Text/Text';
 import { useToastContext } from '@/@common/contexts/useToastContext';
 import { useAddPlaceForm } from '@/domains/places/hooks/useAddPlaceForm';
 import { usePlaceFormValidation } from '@/domains/places/hooks/usePlaceFormValidation';
+import { usePlaceListContext } from '@/layouts/PlaceList/contexts/PlaceListContext';
 
 import addPlace from '../../apis/addPlace';
 import { useFunnel } from '../../hooks/useFunnel';
@@ -24,6 +25,7 @@ const AddPlaceModal = ({ isOpen, onClose }: Omit<ModalProps, 'children'>) => {
   const { isEmpty, isValid } = usePlaceFormValidation(form);
   const { step, nextStep, prevStep, resetFunnel, isStep1, isStep2 } =
     useFunnel();
+  const { handlePlaceAdded } = usePlaceListContext();
 
   const [showErrors, setShowErrors] = useState(false);
   const [placeLocationInfo, setPlaceLocationInfo] =
@@ -67,15 +69,15 @@ const AddPlaceModal = ({ isOpen, onClose }: Omit<ModalProps, 'children'>) => {
 
     try {
       await addPlace(addPlaceForm);
-      if (onPlaceAdded) {
-        await onPlaceAdded();
-      }
+
+      await handlePlaceAdded();
+
       showToast({
         message: '장소가 추가되었습니다.',
         type: 'success',
       });
     } catch (error) {
-      console.log(error);
+      console.error(error);
       showToast({
         message: '장소 추가를 실패하였습니다. 다시 시도해주세요.',
         type: 'error',

--- a/frontend/src/layouts/PlaceList/contexts/PlaceListContext.ts
+++ b/frontend/src/layouts/PlaceList/contexts/PlaceListContext.ts
@@ -6,6 +6,8 @@ export interface PlaceListContextType {
   placeList: PlaceCardProps[];
   refetchPlaceList: () => Promise<void>;
   handleDelete: (id: number) => void;
+  newlyAddedPlace: PlaceCardProps | null;
+  handlePlaceAdded: () => Promise<void>;
 }
 
 export const PlaceListContext = createContext<PlaceListContextType | null>(

--- a/frontend/src/layouts/PlaceList/contexts/PlaceListProvider.tsx
+++ b/frontend/src/layouts/PlaceList/contexts/PlaceListProvider.tsx
@@ -11,6 +11,7 @@ interface Props {
 
 export const PlaceListProvider = ({ children }: Props) => {
   const [placeList, setPlaceList] = useState<PlaceCardProps[]>([]);
+  const [newlyAddedPlace, setNewlyAddedPlace] = useState<PlaceCardProps | null>(null);
 
   const refetchPlaceList = useCallback(async () => {
     try {
@@ -25,13 +26,30 @@ export const PlaceListProvider = ({ children }: Props) => {
     setPlaceList((prev) => prev.filter((place) => place.id !== id));
   }, []);
 
+  const handlePlaceAdded = useCallback(async () => {
+    const previousPlaceIds = placeList.map(place => place.id);
+    
+    try {
+      const newPlaceList = await getPlaceList();
+      setPlaceList(newPlaceList);
+      
+      const newPlace = newPlaceList.find(place => !previousPlaceIds.includes(place.id));
+      if (newPlace) {
+        setNewlyAddedPlace(newPlace);
+        setTimeout(() => setNewlyAddedPlace(null), 500);
+      }
+    } catch (error) {
+      console.error('장소 목록을 불러오는데 실패했습니다.', error);
+    }
+  }, [placeList]);
+
   useEffect(() => {
     refetchPlaceList();
   }, []);
 
   return (
     <PlaceListContext.Provider
-      value={{ placeList, refetchPlaceList, handleDelete }}
+      value={{ placeList, refetchPlaceList, handleDelete, newlyAddedPlace, handlePlaceAdded }}
     >
       {children}
     </PlaceListContext.Provider>

--- a/frontend/src/layouts/SideSheet/SideSheet.tsx
+++ b/frontend/src/layouts/SideSheet/SideSheet.tsx
@@ -1,5 +1,20 @@
-import { ReactNode, useState } from 'react';
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
+
+import Button from '@/@common/components/Button/Button';
+import EmptyMessage from '@/@common/components/EmptyMessage/EmptyMessage';
+import Flex from '@/@common/components/Flex/Flex';
+import Text from '@/@common/components/Text/Text';
+import CloseSheetIcon from '@/assets/icons/closeSheet.svg';
+import AddPlaceModal from '@/domains/places/components/AddPlaceModal/AddPlaceModal';
+import { PlaceCard } from '@/domains/places/components/PlaceCard/PlaceCard';
+import { useRoutieContext } from '@/domains/routie/contexts/useRoutieContext';
+import { useGoogleEventTrigger } from '@/libs/googleAnalytics/hooks/useGoogleEventTrigger';
+import theme from '@/styles/theme';
+
+import { usePlaceListContext } from '../PlaceList/contexts/PlaceListContext';
+
 import {
   SheetBaseStyle,
   SheetContentContainerStyle,
@@ -11,17 +26,6 @@ import {
   SheetListWrapperStyle,
   SheetScrollableAreaStyle,
 } from './SideSheet.styles';
-import CloseSheetIcon from '@/assets/icons/closeSheet.svg';
-import Flex from '@/@common/components/Flex/Flex';
-import Text from '@/@common/components/Text/Text';
-import { usePlaceListContext } from '../PlaceList/contexts/PlaceListContext';
-import { useRoutieContext } from '@/domains/routie/contexts/useRoutieContext';
-import { PlaceCard } from '@/domains/places/components/PlaceCard/PlaceCard';
-import EmptyMessage from '@/@common/components/EmptyMessage/EmptyMessage';
-import Button from '@/@common/components/Button/Button';
-import { useGoogleEventTrigger } from '@/libs/googleAnalytics/hooks/useGoogleEventTrigger';
-import AddPlaceModal from '@/domains/places/components/AddPlaceModal/AddPlaceModal';
-import theme from '@/styles/theme';
 
 interface SideSheetProps {
   open: boolean;

--- a/frontend/src/layouts/SideSheet/SideSheet.tsx
+++ b/frontend/src/layouts/SideSheet/SideSheet.tsx
@@ -33,7 +33,7 @@ interface SideSheetProps {
 }
 
 const SideSheet = ({ open, onToggle }: SideSheetProps) => {
-  const { placeList, refetchPlaceList } = usePlaceListContext();
+  const { placeList } = usePlaceListContext();
   const { routieIdList } = useRoutieContext();
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const { triggerEvent } = useGoogleEventTrigger();

--- a/frontend/src/layouts/SideSheet/SideSheet.tsx
+++ b/frontend/src/layouts/SideSheet/SideSheet.tsx
@@ -106,7 +106,6 @@ const SideSheet = ({ open, onToggle }: SideSheetProps) => {
         <AddPlaceModal
           isOpen={isAddModalOpen}
           onClose={handleCloseAddModalClick}
-          onPlaceAdded={refetchPlaceList}
         />
         <div css={SheetListWrapperStyle}>
           <div css={SheetScrollableAreaStyle}>

--- a/frontend/src/layouts/SideSheet/SideSheet.tsx
+++ b/frontend/src/layouts/SideSheet/SideSheet.tsx
@@ -109,7 +109,12 @@ const SideSheet = ({ open, onToggle }: SideSheetProps) => {
         />
         <div css={SheetListWrapperStyle}>
           <div css={SheetScrollableAreaStyle}>
-            <Flex direction='column' justifyContent='flex-start' gap={1} css={{ overflowY: 'visible' }}>
+            <Flex
+              direction="column"
+              justifyContent="flex-start"
+              gap={1}
+              css={{ overflowY: 'visible' }}
+            >
               {placeList.map((place) => {
                 const selected = routieIdList.includes(place.id);
                 return (


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 장소 목록 & 루티 수정이 일어난 경우 항상 모든 마커의 중심 위치로 지도가 이동하는 것이 불편하다는 피드백을 받음

## To-Be
<!-- 변경 사항 -->
- 마커를 클릭한 경우, 장소를 추가한 경우 해당 마커로 지도 이동
- 첫 렌더링 전체 마커 중심 위치로 이동
- 장소 추가 핸들러 추가
- 자잘한 린트 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
영상은 사이즈 이슈로 슬랙으로 보냈습니다!

## (Optional) Additional Description
- 새 장소가 추가되었는지 체크하기 위한 상태를 추가했습니다
- 새롭게 추가된 핸들러는 이전 장소와 비교하여 새로운 장소 정보를 보관하고 장소 목록을 다시 받아옵니다


Closes #637 
