### PR TITLE
refactor: 루티 스페이스 이름 UI 수정 & 예외 처리 추가

### DIFF
--- a/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.style.ts
+++ b/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.style.ts
@@ -2,19 +2,30 @@ import { css } from '@emotion/react';
 
 import theme from '@/styles/theme';
 
-const routieSpaceNameInputStyle = css`
+const defaultBorder = css`
+  &:focus {
+    outline: 0.3rem solid ${theme.colors.purple[300]};
+  }
+`;
+
+const invalidBorder = css`
+  &:focus {
+    outline: 0.3rem solid ${theme.colors.red[100]};
+  }
+`;
+
+const routieSpaceNameInputStyle = (invalidNameLength: boolean) => css`
   width: 100%;
+  max-width: 38rem;
   margin: 0;
   padding: 0.4rem;
   border: none;
+  border-radius: 8px;
 
   font-size: ${theme.font.size.heading};
   font-weight: ${theme.font.weight.bold};
 
-  &:focus {
-    border-radius: 8px;
-    outline: 0.3rem solid ${theme.colors.purple[300]};
-  }
+  ${invalidNameLength ? invalidBorder : defaultBorder}
 `;
 
 export default routieSpaceNameInputStyle;

--- a/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.tsx
+++ b/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.tsx
@@ -31,7 +31,6 @@ const RoutieSpaceName = () => {
         <input
           ref={inputRef}
           css={routieSpaceNameInputStyle(errorCase === 'invalidNameLength')}
-          maxLength={20}
           autoFocus
           value={name}
           onChange={handleChange}

--- a/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.tsx
+++ b/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.tsx
@@ -1,46 +1,23 @@
-import { useEffect, useState } from 'react';
-
+import Button from '@/@common/components/Button/Button';
 import Flex from '@/@common/components/Flex/Flex';
-import IconButton from '@/@common/components/IconButton/IconButton';
 import Text from '@/@common/components/Text/Text';
-import editIcon from '@/assets/icons/edit.svg';
+import theme from '@/styles/theme';
 
-import {
-  editRoutieSpaceName,
-  getRoutieSpaceName,
-} from '../../apis/routieSpaceName';
+import useRoutieSpaceName from '../../hooks/useRoutieSpaceName';
 
 import routieSpaceNameInputStyle from './RoutieSpaceName.style';
 
 const RoutieSpaceName = () => {
-  const [name, setName] = useState('');
-  const [isEditing, setIsEditing] = useState(false);
-
-  useEffect(() => {
-    const fetchRoutieSpaceName = async () => {
-      const name = await getRoutieSpaceName();
-      setName(name ?? '이름 못 찾음');
-    };
-    fetchRoutieSpaceName();
-  }, []);
-
-  const handleClick = async () => {
-    if (isEditing) {
-      try {
-        const updatedName = await editRoutieSpaceName(name);
-        setName(updatedName ?? '이름 못 찾음');
-      } catch (error) {
-        console.error('루티 스페이스 이름 수정 중 에러 발생:', error);
-      }
-      setIsEditing(false);
-    } else {
-      setIsEditing(true);
-    }
-  };
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setName(e.target.value);
-  };
+  const {
+    name,
+    isEditing,
+    isLoading,
+    errorCase,
+    inputRef,
+    handleEnter,
+    handleClick,
+    handleChange,
+  } = useRoutieSpaceName();
 
   return (
     <Flex
@@ -52,24 +29,25 @@ const RoutieSpaceName = () => {
     >
       {isEditing ? (
         <input
-          id="routie-space-name"
-          css={routieSpaceNameInputStyle}
+          ref={inputRef}
+          css={routieSpaceNameInputStyle(errorCase === 'invalidNameLength')}
           maxLength={20}
           autoFocus
           value={name}
           onChange={handleChange}
+          onKeyDown={handleEnter}
         />
       ) : (
-        <Flex
-          alignItems="center"
-          justifyContent="flex-start"
-          padding={0.4}
-          width="100%"
-        >
+        <Flex justifyContent="flex-start" padding={0.4} width="100%">
           <Text variant="title">{name}</Text>
         </Flex>
       )}
-      <Button variant="primary" onClick={handleClick} width="6.5rem">
+      <Button
+        variant="primary"
+        onClick={handleClick}
+        width="7rem"
+        disabled={isLoading}
+      >
         <Flex width="100%">
           <Text variant="subTitle" color={theme.colors.white}>
             {isEditing ? '저장' : '수정'}

--- a/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.tsx
+++ b/frontend/src/domains/routieSpace/components/RoutieSpaceName/RoutieSpaceName.tsx
@@ -69,7 +69,13 @@ const RoutieSpaceName = () => {
           <Text variant="title">{name}</Text>
         </Flex>
       )}
-      <IconButton icon={editIcon} onClick={handleClick} />
+      <Button variant="primary" onClick={handleClick} width="6.5rem">
+        <Flex width="100%">
+          <Text variant="subTitle" color={theme.colors.white}>
+            {isEditing ? '저장' : '수정'}
+          </Text>
+        </Flex>
+      </Button>
     </Flex>
   );
 };

--- a/frontend/src/domains/routieSpace/hooks/useRoutieSpaceName.ts
+++ b/frontend/src/domains/routieSpace/hooks/useRoutieSpaceName.ts
@@ -25,6 +25,7 @@ interface UseRoutieSpaceNameReturn {
   handleClick: () => Promise<void>;
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
+
 const useRoutieSpaceName = (): UseRoutieSpaceNameReturn => {
   const [name, setName] = useState('');
   const [originalName, setOriginalName] = useState('');

--- a/frontend/src/domains/routieSpace/hooks/useRoutieSpaceName.ts
+++ b/frontend/src/domains/routieSpace/hooks/useRoutieSpaceName.ts
@@ -7,10 +7,10 @@ import {
   getRoutieSpaceName,
 } from '../apis/routieSpaceName';
 
-const MAX_NAME_LENGTH = 20;
+const MAX_NAME_LENGTH = 15;
 const ERROR_MESSAGE = {
   noName: '루티 스페이스 이름은 비어있을 수 없습니다.',
-  invalidNameLength: '루티 스페이스 이름은 20자 이하여야 합니다.',
+  invalidNameLength: '루티 스페이스 이름은 15자 이하여야 합니다.',
 } as const;
 
 type ERROR_CASE = keyof typeof ERROR_MESSAGE;

--- a/frontend/src/domains/routieSpace/hooks/useRoutieSpaceName.ts
+++ b/frontend/src/domains/routieSpace/hooks/useRoutieSpaceName.ts
@@ -10,7 +10,7 @@ import {
 const MAX_NAME_LENGTH = 15;
 const ERROR_MESSAGE = {
   noName: '루티 스페이스 이름은 비어있을 수 없습니다.',
-  invalidNameLength: '루티 스페이스 이름은 15자 이하여야 합니다.',
+  invalidNameLength: `루티 스페이스 이름은 ${MAX_NAME_LENGTH}자 이하여야 합니다.`,
 } as const;
 
 type ERROR_CASE = keyof typeof ERROR_MESSAGE;

--- a/frontend/src/domains/routieSpace/hooks/useRoutieSpaceName.ts
+++ b/frontend/src/domains/routieSpace/hooks/useRoutieSpaceName.ts
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { useToastContext } from '@/@common/contexts/useToastContext';
+
+import {
+  editRoutieSpaceName,
+  getRoutieSpaceName,
+} from '../apis/routieSpaceName';
+
+const MAX_NAME_LENGTH = 20;
+const ERROR_MESSAGE = {
+  noName: '루티 스페이스 이름은 비어있을 수 없습니다.',
+  invalidNameLength: '루티 스페이스 이름은 20자 이하여야 합니다.',
+} as const;
+
+type ERROR_CASE = keyof typeof ERROR_MESSAGE;
+
+interface UseRoutieSpaceNameReturn {
+  name: string;
+  isEditing: boolean;
+  isLoading: boolean;
+  errorCase: ERROR_CASE | null;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  handleEnter: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  handleClick: () => Promise<void>;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+const useRoutieSpaceName = (): UseRoutieSpaceNameReturn => {
+  const [name, setName] = useState('');
+  const [originalName, setOriginalName] = useState('');
+  const [isEditing, setIsEditing] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const { showToast } = useToastContext();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const getErrorCase = (name: string): ERROR_CASE | null => {
+    if (name === '') {
+      return 'noName';
+    }
+    if (name.length > MAX_NAME_LENGTH) {
+      return 'invalidNameLength';
+    }
+
+    return null;
+  };
+
+  const errorCase = getErrorCase(name);
+
+  const handleEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleClick();
+    }
+  };
+
+  const handleClick = async () => {
+    if (isEditing) {
+      if (isLoading) return;
+
+      try {
+        if (errorCase) {
+          showToast({
+            message: ERROR_MESSAGE[errorCase],
+            type: 'error',
+          });
+
+          inputRef.current?.focus();
+          return;
+        }
+
+        if (originalName === name) {
+          setIsEditing(false);
+          return;
+        }
+
+        setIsLoading(true);
+
+        const updatedName = await editRoutieSpaceName(name);
+        const displayName = updatedName ?? '이름 못 찾음';
+
+        setName(displayName);
+        setOriginalName(displayName);
+      } catch (error) {
+        console.error('루티 스페이스 이름 수정 중 에러 발생:', error);
+        showToast({
+          message: '이름 수정에 실패했습니다. 다시 시도해주세요.',
+          type: 'error',
+        });
+        setName(originalName);
+      } finally {
+        setIsLoading(false);
+      }
+      setIsEditing(false);
+    } else {
+      setOriginalName(name);
+      setIsEditing(true);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+  };
+
+  useEffect(() => {
+    const fetchRoutieSpaceName = async () => {
+      try {
+        const name = await getRoutieSpaceName();
+        const displayName = name ?? '이름 못 찾음';
+
+        setName(displayName);
+        setOriginalName(displayName);
+      } catch (error) {
+        console.error('루티 스페이스 이름 불러오기 실패:', error);
+        showToast({
+          message: '이름을 불러오는데 실패했습니다.',
+          type: 'error',
+        });
+        setName('이름 못 찾음');
+        setOriginalName('이름 못 찾음');
+      }
+    };
+
+    fetchRoutieSpaceName();
+  }, []);
+
+  return {
+    name,
+    isEditing,
+    isLoading,
+    errorCase,
+    inputRef,
+    handleEnter,
+    handleClick,
+    handleChange,
+  };
+};
+
+export default useRoutieSpaceName;


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 루티 스페이스 이름을 수정할 때 버튼의 구분이 없어 수정 중인지 수정이 완료된건지 알 수 없었음
- 빈 값을 요청보낼 수 있었고 그에 피드백이 없었음
- 같은 값을 저장해도 api 요청을 보내고 있었음
- 요청을 보내는 중에 다시 요청을 못 보내게 막는 로직이 없었음

## To-Be
<!-- 변경 사항 -->
- 아이콘 버튼에서 그냥 버튼으로 변경
- 빈 값인 경우 요청을 보내지 못하게 막고 토스트를 보여주게 수정
- 15자가 넘어간 경우에 요청을 보내지 못하고 input의 error UI를 보여주게 수정 (토스트도 추가)
- 수정을 하지 않으면 요청을 보내지 않게 수정 (이전 값과 비교)
- isLoading 상태를 추가해 요청중에 중복으로 요청을 보내지 못하게 수정
- enter 키로 저장할 수 있게 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/bffdcf82-49a9-4ea9-82a3-7bc5a8908748

## (Optional) Additional Description
- UI만 수정하려 했는데 에러 UI를 같이 추가하다 보니 로직도 같이 수정하게 되었습니다...🥲
- 원래 20자를 제한으로 두려 했으나 버튼을 추가하고 보니 좁아서 15자로 변경하였습니다


Closes #645 
