### PR TITLE
fix: 지도 sdk에 setTimeOut을 걸어서 잘 읽어오도록 수정

### DIFF
--- a/frontend/src/domains/maps/hooks/useKakaoMapSDK.ts
+++ b/frontend/src/domains/maps/hooks/useKakaoMapSDK.ts
@@ -1,24 +1,43 @@
-import { useEffect, useState } from 'react';
-
+import { useEffect, useRef, useState } from 'react';
 import type { UseKakaoMapSDKReturn } from '../types/KaKaoMap.types';
 
 export const useKakaoMapSDK = (): UseKakaoMapSDKReturn => {
   const [sdkReady, setSdkReady] = useState(false);
   const [sdkError, setSdkError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!window.kakao?.maps) {
-      setSdkError('카카오맵 SDK를 찾을 수 없습니다.');
-      return;
-    }
+  const timersRef = useRef<Map<string, number>>(new Map());
+  const attemptsRef = useRef(0);
 
-    window.kakao.maps.load(() => {
-      setSdkReady(true);
-    });
+  useEffect(() => {
+    const loadSdk = () => {
+      if (!window.kakao?.maps) {
+        if (attemptsRef.current < 10) {
+          attemptsRef.current += 1;
+          setSdkError('카카오맵 불러오는 중 ...');
+
+          const timeoutId = window.setTimeout(loadSdk, 500);
+          timersRef.current.set(`retry_${attemptsRef.current}`, timeoutId);
+        } else {
+          setSdkError('카카오맵 불러오기 실패');
+        }
+        return;
+      }
+
+      window.kakao.maps.load(() => {
+        setSdkReady(true);
+        setSdkError(null);
+      });
+    };
+
+    loadSdk();
+
+    return () => {
+      timersRef.current.forEach((timeoutId) => {
+        window.clearTimeout(timeoutId);
+      });
+      timersRef.current.clear();
+    };
   }, []);
 
-  return {
-    sdkReady,
-    sdkError,
-  };
+  return { sdkReady, sdkError };
 };

--- a/frontend/src/domains/maps/hooks/useKakaoMapSDK.ts
+++ b/frontend/src/domains/maps/hooks/useKakaoMapSDK.ts
@@ -5,7 +5,7 @@ export const useKakaoMapSDK = (): UseKakaoMapSDKReturn => {
   const [sdkReady, setSdkReady] = useState(false);
   const [sdkError, setSdkError] = useState<string | null>(null);
 
-  const timersRef = useRef<Map<string, number>>(new Map());
+  const timerRef = useRef<number | null>(null);
   const attemptsRef = useRef(0);
 
   useEffect(() => {
@@ -15,8 +15,10 @@ export const useKakaoMapSDK = (): UseKakaoMapSDKReturn => {
           attemptsRef.current += 1;
           setSdkError('카카오맵 불러오는 중 ...');
 
-          const timeoutId = window.setTimeout(loadSdk, 500);
-          timersRef.current.set(`retry_${attemptsRef.current}`, timeoutId);
+          if (timerRef.current) {
+            window.window.clearTimeout(timerRef.current);
+          }
+          timerRef.current = window.setTimeout(loadSdk, 500);
         } else {
           setSdkError('카카오맵 불러오기 실패');
         }
@@ -32,10 +34,9 @@ export const useKakaoMapSDK = (): UseKakaoMapSDKReturn => {
     loadSdk();
 
     return () => {
-      timersRef.current.forEach((timeoutId) => {
-        window.clearTimeout(timeoutId);
-      });
-      timersRef.current.clear();
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+      }
     };
   }, []);
 

--- a/frontend/src/domains/maps/hooks/useKakaoMapSDK.ts
+++ b/frontend/src/domains/maps/hooks/useKakaoMapSDK.ts
@@ -16,7 +16,7 @@ export const useKakaoMapSDK = (): UseKakaoMapSDKReturn => {
           setSdkError('카카오맵 불러오는 중 ...');
 
           if (timerRef.current) {
-            window.window.clearTimeout(timerRef.current);
+            window.clearTimeout(timerRef.current);
           }
           timerRef.current = window.setTimeout(loadSdk, 500);
         } else {


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
지도 sdk에 setTimeout을 걸어 약 5초간 불러오고 그 이후에는 에러를 띄우는 로직 구현

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
https://github.com/user-attachments/assets/8e6df7d9-dc6a-44bb-baa6-bc95f401e3b7

https://github.com/user-attachments/assets/b4b77cb9-0591-4fdf-9933-710b30945647


## (Optional) Additional Description

첫 번째 영상은 정상 작동하는 경우이고, 두 번째 영상은 임의로 sdk 오류를 발생시켜 첨부하였습니다.
5초간 읽어오는 시간을 가진 뒤 sdk를 불러온다면 지도를 보여주고, 불러오지 못한다면 실패했다는 문구를 확인할 수 있습니다.

Closes #612 

