### PR TITLE
refactor: RoutiePlace 추가 시 동시성 처리

### DIFF
--- a/backend/spring-routie/src/main/java/routie/routie/domain/RoutiePlace.java
+++ b/backend/spring-routie/src/main/java/routie/routie/domain/RoutiePlace.java
@@ -28,8 +28,8 @@ import routie.place.domain.Place;
         name = "routie_places",
         uniqueConstraints = {
                 @UniqueConstraint(
-                        name = "uk_routie_space_sequence",
-                        columnNames = {"routie_space_id", "sequence"}
+                        name = "uk_routie_space_place",
+                        columnNames = {"routie_space_id", "place_id"}
                 )
         }
 )

--- a/backend/spring-routie/src/main/java/routie/routie/domain/RoutiePlace.java
+++ b/backend/spring-routie/src/main/java/routie/routie/domain/RoutiePlace.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -23,7 +24,15 @@ import routie.place.domain.Place;
 
 @Entity
 @Getter
-@Table(name = "routie_places")
+@Table(
+        name = "routie_places",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_routie_space_sequence",
+                        columnNames = {"routie_space_id", "sequence"}
+                )
+        }
+)
 @EntityListeners(AuditingEntityListener.class)
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/spring-routie/src/main/java/routie/routie/repository/RoutiePlaceRepository.java
+++ b/backend/spring-routie/src/main/java/routie/routie/repository/RoutiePlaceRepository.java
@@ -1,9 +1,16 @@
 package routie.routie.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import routie.routie.domain.RoutiePlace;
 
 @Repository
 public interface RoutiePlaceRepository extends JpaRepository<RoutiePlace, Long> {
+
+    @Modifying
+    @Query("DELETE FROM RoutiePlace rp WHERE rp.place.routieSpace.id = :routieSpaceId")
+    void deleteByRoutieSpaceId(@Param("routieSpaceId") Long routieSpaceId);
 }

--- a/backend/spring-routie/src/test/java/routie/routie/service/RoutieServiceTest.java
+++ b/backend/spring-routie/src/test/java/routie/routie/service/RoutieServiceTest.java
@@ -1,0 +1,232 @@
+package routie.routie.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import routie.exception.BusinessException;
+import routie.place.domain.Place;
+import routie.place.repository.PlaceRepository;
+import routie.routie.controller.dto.request.RoutiePlaceCreateRequest;
+import routie.routie.controller.dto.request.RoutieUpdateRequest;
+import routie.routie.controller.dto.request.RoutieUpdateRequest.RoutiePlaceRequest;
+import routie.routie.domain.RoutiePlace;
+import routie.routie.repository.RoutiePlaceRepository;
+import routie.routiespace.domain.RoutieSpace;
+import routie.routiespace.repository.RoutieSpaceRepository;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RoutieServiceTest {
+
+    @Autowired
+    private RoutieService routieService;
+
+    @Autowired
+    private RoutieSpaceRepository routieSpaceRepository;
+
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private RoutiePlaceRepository routiePlaceRepository;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private RoutieSpace testRoutieSpace;
+    private Place testPlace1;
+    private Place testPlace2;
+    private Place testPlace3;
+
+    @BeforeEach
+    void setUp() {
+        // 기존 데이터 정리
+        transactionTemplate.execute(status -> {
+            routiePlaceRepository.deleteAll();
+            placeRepository.deleteAll();
+            routieSpaceRepository.deleteAll();
+            return null;
+        });
+
+        // 테스트용 데이터 생성
+        transactionTemplate.execute(status -> {
+            // 테스트용 루티 스페이스 생성
+            testRoutieSpace = RoutieSpace.from(() -> "test-routie-space-" + System.currentTimeMillis());
+            routieSpaceRepository.save(testRoutieSpace);
+
+            // 테스트용 장소들 생성
+            testPlace1 = Place.create(
+                    "카페 A",
+                    "서울시 강남구 테헤란로 123",
+                    "서울시 강남구 역삼동 123-45",
+                    127.027926,
+                    37.497175,
+                    60,
+                    LocalTime.of(9, 0),
+                    LocalTime.of(22, 0),
+                    null,
+                    null,
+                    testRoutieSpace,
+                    List.of(DayOfWeek.SUNDAY)
+            );
+
+            testPlace2 = Place.create(
+                    "레스토랑 B",
+                    "서울시 강남구 테헤란로 456",
+                    "서울시 강남구 역삼동 456-78",
+                    127.028926,
+                    37.498175,
+                    90,
+                    LocalTime.of(11, 0),
+                    LocalTime.of(23, 0),
+                    LocalTime.of(15, 0),
+                    LocalTime.of(17, 0),
+                    testRoutieSpace,
+                    List.of()
+            );
+
+            testPlace3 = Place.create(
+                    "쇼핑몰 C",
+                    "서울시 강남구 테헤란로 789",
+                    "서울시 강남구 역삼동 789-12",
+                    127.029926,
+                    37.499175,
+                    120,
+                    LocalTime.of(10, 0),
+                    LocalTime.of(22, 0),
+                    null,
+                    null,
+                    testRoutieSpace,
+                    List.of(DayOfWeek.MONDAY)
+            );
+
+            placeRepository.saveAll(List.of(testPlace1, testPlace2, testPlace3));
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("루티 장소 추가 시 동시성 테스트")
+    void testConcurrentAddRoutiePlace() throws InterruptedException {
+        // Given
+        String routieSpaceIdentifier = testRoutieSpace.getIdentifier();
+        RoutiePlaceCreateRequest request = new RoutiePlaceCreateRequest(testPlace1.getId());
+
+        int threadCount = 10;
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        try (ExecutorService executorService = Executors.newFixedThreadPool(threadCount)) {
+            // When
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        transactionTemplate.execute(status -> {
+                            routieService.addRoutiePlace(routieSpaceIdentifier, request);
+                            return null;
+                        });
+                        successCount.incrementAndGet();
+                    } catch (final Exception e) {
+                        // 실패는 무시
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            boolean finished = latch.await(10, TimeUnit.SECONDS);
+
+            // Then
+            assertThat(finished).isTrue();
+            assertThat(successCount.get()).isEqualTo(1);
+        }
+
+        Long finalCount = transactionTemplate.execute(status ->
+                (long) routiePlaceRepository.findAll().size());
+        assertThat(finalCount).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("루티 순서 수정 테스트 - 순서 변경")
+    @Transactional
+    void testModifyRoutieOrder() {
+        // Given - 초기 루티 설정
+        String routieSpaceIdentifier = testRoutieSpace.getIdentifier();
+
+        // 초기 루티에 장소들 추가
+        routieService.addRoutiePlace(routieSpaceIdentifier, new RoutiePlaceCreateRequest(testPlace1.getId()));
+        routieService.addRoutiePlace(routieSpaceIdentifier, new RoutiePlaceCreateRequest(testPlace2.getId()));
+        routieService.addRoutiePlace(routieSpaceIdentifier, new RoutiePlaceCreateRequest(testPlace3.getId()));
+
+        // 초기 상태 확인
+        List<RoutiePlace> initialPlaces = routiePlaceRepository.findAll();
+        assertThat(initialPlaces).hasSize(3);
+
+        // When - 순서 변경 (1,2,3 -> 3,1,2)
+        RoutieUpdateRequest updateRequest = new RoutieUpdateRequest(List.of(
+                new RoutiePlaceRequest(testPlace3.getId(), 1), // 쇼핑몰 C가 3번째에서 1번째로
+                new RoutiePlaceRequest(testPlace1.getId(), 2), // 카페 A가 1번째에서 2번째로
+                new RoutiePlaceRequest(testPlace2.getId(), 3)  // 레스토랑 B가 2번째에서 3번째로
+        ));
+
+        routieService.modifyRoutie(routieSpaceIdentifier, updateRequest);
+
+        // Then - 순서가 올바르게 변경되었는지 확인
+        List<RoutiePlace> updatedPlaces = routiePlaceRepository.findAll();
+        assertThat(updatedPlaces).hasSize(3);
+
+        // 시퀀스별로 정렬하여 확인
+        updatedPlaces.sort((a, b) -> Integer.compare(a.getSequence(), b.getSequence()));
+
+        assertThat(updatedPlaces.get(0).getPlace().getId()).isEqualTo(testPlace3.getId());
+        assertThat(updatedPlaces.get(0).getSequence()).isEqualTo(1);
+
+        assertThat(updatedPlaces.get(1).getPlace().getId()).isEqualTo(testPlace1.getId());
+        assertThat(updatedPlaces.get(1).getSequence()).isEqualTo(2);
+
+        assertThat(updatedPlaces.get(2).getPlace().getId()).isEqualTo(testPlace2.getId());
+        assertThat(updatedPlaces.get(2).getSequence()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("루티 수정 테스트 - 전체 교체")
+    @Transactional
+    void testModifyRoutieCompleteReplacement() {
+        // Given - 초기 루티 설정
+        String routieSpaceIdentifier = testRoutieSpace.getIdentifier();
+
+        routieService.addRoutiePlace(routieSpaceIdentifier, new RoutiePlaceCreateRequest(testPlace1.getId()));
+        routieService.addRoutiePlace(routieSpaceIdentifier, new RoutiePlaceCreateRequest(testPlace2.getId()));
+
+        // When - 완전히 다른 장소들로 교체
+        RoutieUpdateRequest updateRequest = new RoutieUpdateRequest(List.of(
+                new RoutiePlaceRequest(testPlace3.getId(), 1) // 완전히 새로운 구성
+        ));
+
+        routieService.modifyRoutie(routieSpaceIdentifier, updateRequest);
+
+        // Then - 새로운 구성으로 교체되었는지 확인
+        List<RoutiePlace> updatedPlaces = routiePlaceRepository.findAll();
+        assertThat(updatedPlaces).hasSize(1);
+        assertThat(updatedPlaces.get(0).getPlace().getId()).isEqualTo(testPlace3.getId());
+        assertThat(updatedPlaces.get(0).getSequence()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 루티에 장소 추가 시 동시성 문제 발생

## To-Be
<!-- 변경 사항 -->
- 동시성 문제 해결 및 루티 수정 로직 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
* 동시성 문제를 해결하기 위해 가장 간단한 방법으로 routie_space_id + place_id를 유니크 제약 조건
  * routie_space_id + sequence를 제약 조건으로 걸지 않은 이유는 아래에 설명
* 제약 조건을 걸 시 기존 루티 수정 api에서 예외 발생.
  * 삭제 후 삽입 시 JPA에서 INSERT 이후 DELETE 쿼리 실행해 제약 조건에 반함
* 삭제 후 강제로 flush 및 영속성 컨텍스트 clear 실행.
  * 이 둘을 실행해야하는 이유 아래에 설명

* routie_space_id + sequence를 제약조건 걸 때 문제점
  * 순서 변경 시 임시 중복 발생: 1,2,3 → 3,1,2로 변경할 때 중간 과정에서 sequence 값이 겹쳐 제약조건 위반
* flush 및 영속성 컨텍스트 clear 실행 이유
  * flush: DELETE 쿼리를 즉시 DB에 반영하여 INSERT 전에 기존 데이터 완전 삭제 보장
  * clear: 삭제된 엔티티들을 영속성 컨텍스트에서 제거하여 OptimisticLockingFailureException 방지

* 다른 구현보다 영속성 컨텍스트 clear을 실행한 이유
  * Update 쿼리 실행
     * 복잡한 변경 감지 로직 필요: 추가/삭제/순서변경을 각각 구분하여 처리해야 하며 코드 복잡도 증가
  * 락
     * 동시성 처리를 위한 추가 인프라 필요: 메모리 관리 및 성능 오버헤드 발생으로 단순한 제약조건 방식보다 복잡함
  - 가장 큰 이유는 구현 시간의 한계
<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #642 