### PR TITLE
fix: 도로명 주소가 없는 경우, 지번 주소가 입력되고 다음 입력 스텝으로 이동되도록 수정

### DIFF
--- a/frontend/src/domains/places/components/AddPlaceModal/AddPlaceBasicInfo.tsx
+++ b/frontend/src/domains/places/components/AddPlaceModal/AddPlaceBasicInfo.tsx
@@ -38,7 +38,7 @@ const AddPlaceBasicInfo = ({
         disabled
       />
       <AddressInput
-        value={form.roadAddressName}
+        value={form.roadAddressName || form.addressName}
         onChange={handleInputChange}
         error={showErrors && isEmpty.roadAddressName}
         disabled

--- a/frontend/src/domains/places/constants/step.ts
+++ b/frontend/src/domains/places/constants/step.ts
@@ -1,5 +1,5 @@
 export const STEP_REQUIRED_FIELDS = {
-  1: ['name', 'roadAddressName', 'stayDurationMinutes'],
+  1: ['name', 'roadAddressName', 'addressName', 'stayDurationMinutes'],
   2: ['openAt', 'closeAt', 'closedDayOfWeeks'],
 };
 

--- a/frontend/src/domains/places/hooks/usePlaceFormValidation.ts
+++ b/frontend/src/domains/places/hooks/usePlaceFormValidation.ts
@@ -4,6 +4,7 @@ export const usePlaceFormValidation = (form: FormState) => {
   const isEmpty = {
     name: form.name.trim() === '',
     roadAddressName: form.roadAddressName.trim() === '',
+    addressName: form.addressName.trim() === '',
     stayDurationMinutes: form.stayDurationMinutes < 0,
     openAt: form.openAt === '',
     closeAt: form.closeAt === '',
@@ -17,7 +18,12 @@ export const usePlaceFormValidation = (form: FormState) => {
 };
 
 export const usePlaceFormRequiredFieldsValidation = (form: FormState) => {
-  if (!form.name || !form.roadAddressName || !form.openAt || !form.closeAt) {
+  if (
+    !form.name ||
+    !(form.roadAddressName || form.addressName) ||
+    !form.openAt ||
+    !form.closeAt
+  ) {
     return false;
   }
 

--- a/frontend/src/domains/places/utils/getValidatedStep.ts
+++ b/frontend/src/domains/places/utils/getValidatedStep.ts
@@ -4,5 +4,10 @@ export const getValidatedStep = (
   step: 1 | 2,
   isEmpty: Record<string, boolean>,
 ) => {
-  return STEP_REQUIRED_FIELDS[step].every((key) => !isEmpty[key]);
+  return STEP_REQUIRED_FIELDS[step].every((key) => {
+    if (step === 1) {
+      return !isEmpty['roadAddressName'] || !isEmpty['addressName'];
+    }
+    return !isEmpty[key];
+  });
 };


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 도로명 주소가 없는 경우, 지번 주소가 입력되지 않음.
- 지번에 대한 유효성 검사가 되지 않음.

## To-Be
<!-- 변경 사항 -->
- 도로명 주소가 없는 경우, 지번 주소가 입력.
- 지번에 대한 유효성 검사 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
https://github.com/user-attachments/assets/2b7be350-0282-489d-a8e0-110fabd269d3

## (Optional) Additional Description

Closes #609 
