### PR TITLE
refactor: 장소 삭제 시 비즈니스 예외 추가

### DIFF
--- a/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
+++ b/backend/spring-routie/src/main/java/routie/exception/ErrorCode.java
@@ -147,6 +147,11 @@ public enum ErrorCode {
             "해당하는 id의 장소를 찾을 수 없습니다.",
             HttpStatus.NOT_FOUND
     ),
+    ROUTIE_PLACE_EXIST(
+            "1103",
+            "장소가 루티 장소에 등록되어 있습니다.",
+            HttpStatus.BAD_REQUEST
+    ),
 
     /**
      * 2XXX: Routie Space domain

--- a/backend/spring-routie/src/main/java/routie/place/service/PlaceService.java
+++ b/backend/spring-routie/src/main/java/routie/place/service/PlaceService.java
@@ -14,6 +14,7 @@ import routie.exception.BusinessException;
 import routie.exception.ErrorCode;
 import routie.place.repository.PlaceClosedDayOfWeekRepository;
 import routie.place.repository.PlaceRepository;
+import routie.routie.repository.RoutiePlaceRepository;
 import routie.routiespace.domain.RoutieSpace;
 import routie.routiespace.repository.RoutieSpaceRepository;
 
@@ -25,6 +26,7 @@ public class PlaceService {
     private final PlaceRepository placeRepository;
     private final RoutieSpaceRepository routieSpaceRepository;
     private final PlaceClosedDayOfWeekRepository placeClosedDayOfWeekRepository;
+    private final RoutiePlaceRepository routiePlaceRepository;
 
     public PlaceReadResponse getPlace(final String routieSpaceIdentifier, final long placeId) {
         final RoutieSpace routieSpace = getRoutieSpaceByIdentifier(routieSpaceIdentifier);
@@ -88,6 +90,9 @@ public class PlaceService {
         RoutieSpace routieSpace = getRoutieSpaceByIdentifier(routieSpaceIdentifier);
         if (!placeRepository.existsByIdAndRoutieSpace(placeId, routieSpace)) {
             throw new BusinessException(ErrorCode.PLACE_NOT_FOUND);
+        }
+        if (routiePlaceRepository.existsRoutiePlaceByPlaceId(placeId)) {
+            throw new BusinessException(ErrorCode.ROUTIE_PLACE_EXIST);
         }
         placeRepository.deleteById(placeId);
     }

--- a/backend/spring-routie/src/main/java/routie/routie/repository/RoutiePlaceRepository.java
+++ b/backend/spring-routie/src/main/java/routie/routie/repository/RoutiePlaceRepository.java
@@ -6,4 +6,5 @@ import routie.routie.domain.RoutiePlace;
 
 @Repository
 public interface RoutiePlaceRepository extends JpaRepository<RoutiePlace, Long> {
+    boolean existsRoutiePlaceByPlaceId(Long placeId);
 }


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 루티 장소로 등록된 장소를 삭제 시 DB 예외 발생

## To-Be
<!-- 변경 사항 -->
- 장소를 삭제 시 미리 확인해 비즈니스 예외 발생

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #651 