### PR TITLE
refactor: identifier를 쿼리 파람에 먼저 등록할 수 있게 수정

### DIFF
--- a/frontend/src/domains/routieSpace/apis/createRoutieSpace.ts
+++ b/frontend/src/domains/routieSpace/apis/createRoutieSpace.ts
@@ -14,5 +14,5 @@ export const createRoutieSpace = async () => {
     throw new Error('루티 스페이스 UUID가 응답에 없습니다.');
   }
 
-  localStorage.setItem('routieSpaceUuid', uuid);
+  return uuid;
 };

--- a/frontend/src/pages/Home/hooks/useRoutieSpaceNavigation.ts
+++ b/frontend/src/pages/Home/hooks/useRoutieSpaceNavigation.ts
@@ -10,10 +10,13 @@ export const useRoutieSpaceNavigation = () => {
 
   const handleCreateRoutieSpace = useCallback(async () => {
     try {
-      await createRoutieSpace();
-      const newUuid = localStorage.getItem('routieSpaceUuid');
-      if (!newUuid) return;
-      navigate(`/routie-spaces?routieSpaceIdentifier=${newUuid}`);
+      const newUuid = await createRoutieSpace();
+      const queryParams = new URLSearchParams({
+        routieSpaceIdentifier: newUuid,
+      });
+
+      navigate(`/routie-spaces?${queryParams.toString()}`);
+
       showToast({
         message: '새 루티 스페이스가 생성되었습니다',
         type: 'success',

--- a/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
+++ b/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router';
+
 import Flex from '@/@common/components/Flex/Flex';
 import { RoutieProvider } from '@/domains/routie/contexts/useRoutieContext';
 import { RoutieValidateProvider } from '@/domains/routie/contexts/useRoutieValidateContext';
@@ -6,6 +9,15 @@ import { PlaceListProvider } from '@/layouts/PlaceList/contexts/PlaceListProvide
 import Sidebar from '@/layouts/Sidebar/Sidebar';
 
 const RoutieSpace = () => {
+  const [searchParams] = useSearchParams();
+  const routieSpaceIdentifier = searchParams.get('routieSpaceIdentifier');
+
+  useEffect(() => {
+    if (routieSpaceIdentifier) {
+      localStorage.setItem('routieSpaceUuid', routieSpaceIdentifier);
+    }
+  }, [routieSpaceIdentifier]);
+
   return (
     <RoutieValidateProvider>
       <RoutieProvider>


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- identifier를 로컬 스토리지에 먼저 저장했기 때문에 url 공유로 다른 곳에서 같은 루티 스페이스에 접속이 불가능

## To-Be
<!-- 변경 사항 -->
#### 기존 플로우
1. 루티 생성 요청
2. response에서 받은 identifier 로컬 스토리지에 저장 -> api 요청 로직에서
3. 루티 스페이스로 리다이렉트

#### 변경된 플로우
1. 루티 스페이스 생성 요청
2. identifier를 return
3. 루티 스페이스로 이동
4. 루티 스페이스에서 쿼리를 확인해 로컬 스토리지에 저장


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
추가로 존재하지 않는 루티 스페이스에 접속할 경우 홈으로 리다이렉트 시키는 예외 처리를 추가해야 하지만 routieSpaceName 쪽 로직을 수정해야 하기 때문에 [루티 스페이스 이름 pr](https://github.com/woowacourse-teams/2025-routie/pull/646)이 Merge 되면 작업할 수 있을 것 같습니다 🥲


Closes #430 
