### PR TITLE
feat: useAsyncLock / useDebouncedAsync 적용으로 중복,연속 요청 방지

### DIFF
--- a/frontend/src/@common/hooks/useAsyncLock.ts
+++ b/frontend/src/@common/hooks/useAsyncLock.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 
-export function useAsyncLock() {
+export const useAsyncLock = () => {
   const isLockedRef = useRef(false);
   const [loading, setLoading] = useState(false);
 

--- a/frontend/src/@common/hooks/useAsyncLock.ts
+++ b/frontend/src/@common/hooks/useAsyncLock.ts
@@ -1,0 +1,25 @@
+import { useCallback, useRef, useState } from 'react';
+
+export function useAsyncLock() {
+  const isLockedRef = useRef(false);
+  const [loading, setLoading] = useState(false);
+
+  const runWithLock = useCallback(
+    async <T>(fn: () => Promise<T>): Promise<T | undefined> => {
+      if (isLockedRef.current) return undefined;
+
+      isLockedRef.current = true;
+      setLoading(true);
+
+      try {
+        return await fn();
+      } finally {
+        isLockedRef.current = false;
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  return { runWithLock, loading, isLockedRef };
+}

--- a/frontend/src/@common/hooks/useDebounceAsync.ts
+++ b/frontend/src/@common/hooks/useDebounceAsync.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export function useDebouncedAsync<T extends (...args: any[]) => Promise<any>>(
+  asyncFn: T,
+  delay: number,
+) {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const callbackRef = useRef<T>(asyncFn);
+  useEffect(() => {
+    callbackRef.current = asyncFn;
+  }, [asyncFn]);
+
+  const debouncedFn = useCallback(
+    (...args: Parameters<T>): Promise<ReturnType<T>> => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+
+      return new Promise<ReturnType<T>>((resolve, reject) => {
+        timeoutRef.current = setTimeout(async () => {
+          try {
+            const result = await callbackRef.current(...args);
+            resolve(result as ReturnType<T>);
+          } catch (error) {
+            reject(error);
+          }
+        }, delay);
+      });
+    },
+    [delay],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  return debouncedFn as T;
+}

--- a/frontend/src/@common/hooks/useDebounceAsync.ts
+++ b/frontend/src/@common/hooks/useDebounceAsync.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-export function useDebounceAsync<T extends (...args: any[]) => Promise<any>>(
+export const useDebounceAsync = <T extends (...args: any[]) => Promise<any>>(
   asyncFn: T,
   delay: number,
-) {
+) => {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const callbackRef = useRef<T>(asyncFn);
@@ -36,4 +36,4 @@ export function useDebounceAsync<T extends (...args: any[]) => Promise<any>>(
   }, []);
 
   return debouncedFn as T;
-}
+};

--- a/frontend/src/@common/hooks/useDebounceAsync.ts
+++ b/frontend/src/@common/hooks/useDebounceAsync.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-export function useDebouncedAsync<T extends (...args: any[]) => Promise<any>>(
+export function useDebounceAsync<T extends (...args: any[]) => Promise<any>>(
   asyncFn: T,
   delay: number,
 ) {

--- a/frontend/src/domains/places/components/EditPlaceModal/EditPlaceModal.tsx
+++ b/frontend/src/domains/places/components/EditPlaceModal/EditPlaceModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { useToastContext } from '@/@common/contexts/useToastContext';
 import Flex from '@/@common/components/Flex/Flex';
 import Modal, { ModalProps } from '@/@common/components/Modal/Modal';
+import { useToastContext } from '@/@common/contexts/useToastContext';
+import { useAsyncLock } from '@/@common/hooks/useAsyncLock';
 import { useRoutieContext } from '@/domains/routie/contexts/useRoutieContext';
 
 import editPlace from '../../apis/editPlace';
@@ -71,6 +72,8 @@ const EditPlaceModal = ({
 
   const placeInRoutie = routieIdList.includes(id);
 
+  const { runWithLock: runSubmitWithLock } = useAsyncLock();
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!isValid) {
@@ -78,27 +81,30 @@ const EditPlaceModal = ({
 
       return;
     }
-    try {
-      const { name, roadAddressName, ...rest } = form;
 
-      await editPlace({ placeId: id, editableFields: rest });
-      await onPlaceChange();
+    return runSubmitWithLock(async () => {
+      try {
+        const { name, roadAddressName, ...rest } = form;
 
-      if (placeInRoutie) {
-        await refetchRoutieData();
+        await editPlace({ placeId: id, editableFields: rest });
+        await onPlaceChange();
+
+        if (placeInRoutie) {
+          await refetchRoutieData();
+        }
+        showToast({
+          message: '장소 정보가 수정되었습니다.',
+          type: 'success',
+        });
+      } catch (error) {
+        console.error(error);
+        showToast({
+          message: '장소 정보를 수정하지 못했습니다. 다시 시도해주세요.',
+          type: 'error',
+        });
       }
-      showToast({
-        message: '장소 정보가 수정되었습니다.',
-        type: 'success',
-      });
-    } catch (error) {
-      console.log(error);
-      showToast({
-        message: '장소 정보를 수정하지 못했습니다. 다시 시도해주세요.',
-        type: 'error',
-      });
-    }
-    handleClose();
+      handleClose();
+    });
   };
 
   return (

--- a/frontend/src/domains/routie/components/Route/RoutieRoutes.tsx
+++ b/frontend/src/domains/routie/components/Route/RoutieRoutes.tsx
@@ -15,12 +15,23 @@ interface RoutieRoutesProps {
 }
 
 const RoutieRoutes = ({ routieId, routes }: RoutieRoutesProps) => {
-  const { movingStrategy } = useRoutieContext();
+  const { movingStrategy, fetchedStrategy } = useRoutieContext();
 
-  return (
-    <Flex key={routieId} margin={1} gap={1}>
+  const isUpdating = movingStrategy !== fetchedStrategy;
+
+  return isUpdating ? (
+    <Flex key={routieId} margin={1} gap={1} alignItems="center">
+      <Text variant="description">--- ---</Text>
+      <Pill type="distance">
+        <Text variant="description" color={theme.colors.purple[400]}>
+          --- km
+        </Text>
+      </Pill>
+    </Flex>
+  ) : (
+    <Flex key={routieId} margin={1} gap={1} alignItems="center">
       <Text variant="description">
-        {MOVING_EN_TO_KR[movingStrategy]}{' '}
+        {MOVING_EN_TO_KR[fetchedStrategy]}{' '}
         {formatMinutesToHours(routes.duration)}
       </Text>
       <Pill type="distance">

--- a/frontend/src/domains/routie/components/Route/RoutieRoutes.tsx
+++ b/frontend/src/domains/routie/components/Route/RoutieRoutes.tsx
@@ -20,7 +20,7 @@ const RoutieRoutes = ({ routieId, routes }: RoutieRoutesProps) => {
   const isUpdating = movingStrategy !== fetchedStrategy;
 
   return isUpdating ? (
-    <Flex key={routieId} margin={1} gap={1} alignItems="center">
+    <Flex key={routieId} margin={1} gap={1}>
       <Text variant="description">--- ---</Text>
       <Pill type="distance">
         <Text variant="description" color={theme.colors.purple[400]}>
@@ -29,7 +29,7 @@ const RoutieRoutes = ({ routieId, routes }: RoutieRoutesProps) => {
       </Pill>
     </Flex>
   ) : (
-    <Flex key={routieId} margin={1} gap={1} alignItems="center">
+    <Flex key={routieId} margin={1} gap={1}>
       <Text variant="description">
         {MOVING_EN_TO_KR[fetchedStrategy]}{' '}
         {formatMinutesToHours(routes.duration)}

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -54,6 +54,8 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
   const { movingStrategy, setMovingStrategy } = useMovingStrategy();
   const { showToast } = useToastContext();
 
+  const sortBySequence = (a: Routie, b: Routie) => a.sequence - b.sequence;
+
   const refetchRoutieData = useCallback(async () => {
     try {
       const routies = await getRoutie(
@@ -61,7 +63,8 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
         combineDateTime.startDateTime,
         movingStrategy,
       );
-      setRoutiePlaces(routies.routiePlaces);
+      const sortedPlaces = [...routies.routiePlaces].sort(sortBySequence);
+      setRoutiePlaces(sortedPlaces);
       setRoutes(routies.routes);
       validateRoutie(movingStrategy, routies.routiePlaces.length);
     } catch (error) {

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -31,6 +31,7 @@ type RoutieContextType = {
   routieIdList: number[];
   movingStrategy: MovingStrategyType;
   setMovingStrategy: (strategy: MovingStrategyType) => void;
+  fetchedStrategy: MovingStrategyType;
 };
 
 const RoutieContext = createContext<RoutieContextType>({
@@ -43,6 +44,7 @@ const RoutieContext = createContext<RoutieContextType>({
   routieIdList: [],
   movingStrategy: 'DRIVING',
   setMovingStrategy: () => {},
+  fetchedStrategy: 'DRIVING',
 });
 
 export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
@@ -52,6 +54,8 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
   const { isValidateActive, combineDateTime, validateRoutie } =
     useRoutieValidateContext();
   const { movingStrategy, setMovingStrategy } = useMovingStrategy();
+  const [fetchedStrategy, setFetchedStrategy] =
+    useState<MovingStrategyType>(movingStrategy);
   const { showToast } = useToastContext();
 
   const sortBySequence = (a: Routie, b: Routie) => a.sequence - b.sequence;
@@ -67,6 +71,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
       setRoutiePlaces(sortedPlaces);
       setRoutes(routies.routes);
       validateRoutie(movingStrategy, routies.routiePlaces.length);
+      setFetchedStrategy(movingStrategy);
     } catch (error) {
       console.error(error);
       showToast({
@@ -158,6 +163,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
         handleChangeRoutie,
         movingStrategy,
         setMovingStrategy,
+        fetchedStrategy,
       }}
     >
       {children}

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -2,9 +2,8 @@ import {
   createContext,
   useCallback,
   useContext,
-  useState,
   useEffect,
-  useCallback,
+  useState,
 } from 'react';
 
 import { useToastContext } from '@/@common/contexts/useToastContext';
@@ -76,7 +75,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
       const sortedPlaces = [...routies.routiePlaces].sort(sortBySequence);
       setRoutiePlaces(sortedPlaces);
       setRoutes(routies.routes);
-      validateRoutie(movingStrategy, routies.routiePlaces.length);
+      await validateRoutie(movingStrategy, routies.routiePlaces.length);
       setFetchedStrategy(movingStrategy);
     } catch (error) {
       console.error(error);
@@ -90,6 +89,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
     combineDateTime.startDateTime,
     validateRoutie,
     movingStrategy,
+    showToast,
   ]);
 
   const debouncedRefetchRoutieData = useDebounceAsync(refetchRoutieData, 300);
@@ -147,7 +147,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
         .sort((a, b) => a.sequence - b.sequence);
       try {
         await editRoutieSequence(sortedList);
-        refetchRoutieData();
+        await refetchRoutieData();
       } catch (error) {
         console.error(error);
         showToast({
@@ -156,7 +156,7 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
         });
       }
     },
-    [refetchRoutieData],
+    [refetchRoutieData, showToast],
   );
 
   useEffect(() => {

--- a/frontend/src/domains/routie/contexts/useRoutieContext.tsx
+++ b/frontend/src/domains/routie/contexts/useRoutieContext.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  useCallback,
   useContext,
   useState,
   useEffect,
@@ -8,6 +9,7 @@ import {
 
 import { useToastContext } from '@/@common/contexts/useToastContext';
 import { useAsyncLock } from '@/@common/hooks/useAsyncLock';
+import { useDebounceAsync } from '@/@common/hooks/useDebounceAsync';
 
 import {
   addRoutiePlace,
@@ -90,6 +92,8 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
     movingStrategy,
   ]);
 
+  const debouncedRefetchRoutieData = useDebounceAsync(refetchRoutieData, 300);
+
   const handleAddRoutie = useCallback(
     async (id: number) => {
       return runAddWithLock(async () => {
@@ -156,8 +160,14 @@ export const RoutieProvider = ({ children }: { children: React.ReactNode }) => {
   );
 
   useEffect(() => {
-    refetchRoutieData();
-  }, [isValidateActive, combineDateTime, movingStrategy]);
+    debouncedRefetchRoutieData();
+  }, [
+    isValidateActive,
+    movingStrategy,
+    combineDateTime.startDateTime,
+    combineDateTime.endDateTime,
+    debouncedRefetchRoutieData,
+  ]);
 
   return (
     <RoutieContext.Provider

--- a/frontend/src/domains/routie/hooks/useRoutieValidate.ts
+++ b/frontend/src/domains/routie/hooks/useRoutieValidate.ts
@@ -1,15 +1,15 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useSessionStorage } from '@/@common/hooks/useSessionStorage';
 import { getCombineDateTime } from '@/@common/utils/format';
 
 import { getRoutieValidation } from '../apis/routie';
 import {
-  ValidationResultType,
+  InvalidRoutiePlace,
   validationErrorCodeType,
+  ValidationResultType,
   ValidationStatus,
   WaitingReason,
-  InvalidRoutiePlace,
 } from '../types/routie.types';
 
 export interface UseRoutieValidateReturn {
@@ -173,6 +173,12 @@ const useRoutieValidate = (): UseRoutieValidateReturn => {
     },
     [getValidationConditions, updateValidationStatus, combineDateTime],
   );
+
+  useEffect(() => {
+    if (!isValidateActive) {
+      setInvalidResult(null);
+    }
+  }, [isValidateActive]);
 
   return {
     isValidateActive,


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 루티 장소 관련 비동기 처리에서 버튼을 빠르게 누르면 중복 요청과 불필요한 연속 호출이 발생
- 검증 토글 비활성화 시에도 invalid place 정보가 초기화되지 않는 문제

## To-Be
<!-- 변경 사항 -->
- 중복 요청 방지를 위한 `useAsyncLock` 훅 추가 및 적용  
  - 해당 훅은 promise 함수를 받아, 함수 실행이 완료되기 전까지는 다른 요청이 실행되지 않도록 하는 훅입니다.
  - 적용 대상: AddPlaceModal, EditPlaceModal, PlaceCard 
  - (장소 목록에 장소 추가, 수정, 삭제 / 루티에 장소 추가, 삭제 로직은 중복 요청이 발생하면 안 되기 때문에 적용)

- 불필요한 연속 요청 방지를 위한 `useDebouncedAsync` 훅 추가 및 적용  
  - 해당 훅은 promise 함수와 지연 시간을 받아, 주어진 시간 안에 새로운 호출이 없을 때만 함수를 실행합니다.  
  - 만약 지연 시간 내에 새로운 호출이 들어오면 이전 호출은 취소되고, 마지막 호출만 실행되도록 합니다.  
  - 적용 대상: 검증 토글, 이동 수단 선택, 일정 시작, 종료 시간 선택 이후 호출되는 `refetchRoutieData`→ 300ms 디바운스를 적용하여 불필요한 연속 호출 차단 
  - (검증 토글, 이동 수단 선택, 일정 시작, 종료 시간 선택을 계속해서 빠르게 클릭하면 불필요하게 연속 요청이 가서 마지막 요청만 처리될 수 있게 적용)

- 서버의 루티 응답이 sequence 로 정렬되어서 오지 않게 변경되어 refetch 후 루티 장소를 sequence 순서대로 sort 해서 상태를 저장하는 로직 추가하였습니다. 첫번째 커밋에서 확인할 수 있습니다

- API 응답 상태를 기반으로 UI 렌더링 개선  
  - 기존에는 이동 수단 선택 시, React 상태인 `movingStrategy`가 먼저 변경되고 이후 서버 응답(`duration`, `distance`)이 들어오면서 화면이 두 번 변경되는 문제가 있었습니다.  
  - 서버 응답이 도착한 후 상태가 변경되도록 `fetchedStrategy`를 추가하여, 화면이 한 번만 변경되도록 개선했습니다.

- 검증 토글 비활성화 시에도 invalid place 정보가 그대로 표시되던 문제 해결  
  - 토글이 꺼질 경우 invalid place 정보를 초기화하도록 수정했습니다.

- import 정리, 누락된 await 보완, 의존성 배열 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
개발자도구 -> 네트워크 탭 -> 제한 없음을 3G로 설정하고 연속 클릭 해보시면 테스트 해보실 수 있습니다🙇‍♀️


## (Optional) Additional Description
이번 PR은 변경 범위가 조금 넓어 커밋을 최대한 잘게 쪼개 두었습니다.😭
혹시 이해가 어려운 부분이 있다면 언제든 저에게 바로 질문 주시거나 코멘트 남겨주세요!🙇‍♀️

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
close #638 
