### PR TITLE
fix: 시작 시간이 종료 시간보다 뒤일 때 검증 요청 차단 및 에러 표시

### DIFF
--- a/frontend/src/@common/utils/isTimeRangeInvalid .ts
+++ b/frontend/src/@common/utils/isTimeRangeInvalid .ts
@@ -1,0 +1,7 @@
+export const isTimeRangeInvalid = (
+  startTime: string,
+  endTime: string,
+): boolean => {
+  if (!startTime || !endTime) return false;
+  return endTime < startTime;
+};

--- a/frontend/src/layouts/Sidebar/TimeInput.tsx
+++ b/frontend/src/layouts/Sidebar/TimeInput.tsx
@@ -2,12 +2,17 @@ import Flex from '@/@common/components/Flex/Flex';
 import Input from '@/@common/components/Input/Input';
 import { useRoutieValidateContext } from '@/domains/routie/contexts/useRoutieValidateContext';
 
+import { isTimeRangeInvalid } from '../../@common/utils/isTimeRangeInvalid ';
+
 const TimeInput = () => {
   const { isValidateActive, routieTime, handleTimeChange } =
     useRoutieValidateContext();
 
+  const error = isTimeRangeInvalid(routieTime.startTime, routieTime.endTime);
+
   const scheduleInputVariant =
     isValidateActive && routieTime.date !== '' ? 'primary' : 'disabled';
+  const endInputVariant = error ? 'error' : scheduleInputVariant;
 
   return (
     <Flex justifyContent="space-between" width="100%" gap={1}>
@@ -25,7 +30,7 @@ const TimeInput = () => {
       </Flex>
       <Flex direction="column" alignItems="flex-start" gap={1} width="100%">
         <Input
-          variant={scheduleInputVariant}
+          variant={endInputVariant}
           disabled={
             routieTime.date === '' ||
             routieTime.startTime === '' ||


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 종료 시간이 시작 시간보다 앞선 경우에도 서버에 검증 요청이 전송되어 에러가 발생함

## To-Be
<!-- 변경 사항 -->
- 시작 시간이 종료 시간보다 뒤일 경우 프론트에서 요청 자체를 차단
- 종료 시간 input에 `error` variant 적용하여 즉시 시각적으로 표시
- 잘못된 시간 범위일 때 서버로 요청하지 않고 토스트를 즉시 노출

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

https://github.com/user-attachments/assets/8373c4ee-3a13-4a35-84d5-ab2511f2e7ea



<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
close #629 
