### PR TITLE
fix: identifier가 저정되기 전에 다른 api에서 참조하는 문제 수정

### DIFF
--- a/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
+++ b/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { useSearchParams } from 'react-router';
 
 import Flex from '@/@common/components/Flex/Flex';
@@ -12,7 +12,7 @@ const RoutieSpace = () => {
   const [searchParams] = useSearchParams();
   const routieSpaceIdentifier = searchParams.get('routieSpaceIdentifier');
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (routieSpaceIdentifier) {
       localStorage.setItem('routieSpaceUuid', routieSpaceIdentifier);
     }


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- useEffect는 렌더링 이후에 실행하기 때문에 렌더링 이후에 값을 로컬에 저장
- 다른 api 호출에서 값이 저장되기 전에 참조해 api를 호출하기 때문에 문제가 발생


## To-Be
<!-- 변경 사항 -->
- useLayoutEffect는 렌더링 전에 실행하기 때문에 이런 문제를 해결할 수 있습니다
- 성능에 영향을 끼칠 로직은 이 방식을 사용하지 않는 것이 좋지만 로컬 스토리지에 값을 저장하는 정도의 로직은 실행해도 문제 없을 것 같습니다

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


Closes #683 
