### PR TITLE
fix: 지도 마커 카드에서 지번 주소도 보이도록 수정

### DIFF
--- a/frontend/src/domains/maps/components/PlaceOverlayCard.tsx
+++ b/frontend/src/domains/maps/components/PlaceOverlayCard.tsx
@@ -57,7 +57,7 @@ const PlaceOverlayCard = ({ place, onClose }: Props) => {
           {place.name}
         </Text>
         <Text variant="caption" color={theme.colors.gray[200]} ellipsis>
-          {place.roadAddressName}
+          {place.roadAddressName || place.addressName}
         </Text>
         <Pill type="time">
           {place.openAt}-{place.closeAt}


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
지도 마커 카드에서 도로명 주소는 잘 보이지만, 지번 주소가 보이지 않는 문제 발견 

## To-Be
<!-- 변경 사항 -->
- 지도 마커 카드에서 지번 주소도 보이도록 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="285" height="232" alt="image" src="https://github.com/user-attachments/assets/d2b4a015-af50-4288-bffc-2762452a3cae" />


## (Optional) Additional Description

Closes #685 
