### PR TITLE
refactor: 쿼리 파라미터 기반의 api 버저닝 구현

### DIFF
--- a/backend/spring-routie/src/main/java/routie/global/versioning/config/ApiVersionConfig.java
+++ b/backend/spring-routie/src/main/java/routie/global/versioning/config/ApiVersionConfig.java
@@ -1,0 +1,29 @@
+package routie.global.versioning.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import routie.global.versioning.infrastructure.ApiVersionArgumentResolver;
+import routie.global.versioning.infrastructure.ApiVersionInterceptor;
+
+@Configuration
+@RequiredArgsConstructor
+public class ApiVersionConfig implements WebMvcConfigurer {
+
+    private final ApiVersionInterceptor apiVersionInterceptor;
+    private final ApiVersionArgumentResolver apiVersionArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(apiVersionArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(apiVersionInterceptor)
+                .addPathPatterns("/api/**");
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/global/versioning/domain/ApiVersion.java
+++ b/backend/spring-routie/src/main/java/routie/global/versioning/domain/ApiVersion.java
@@ -1,0 +1,12 @@
+package routie.global.versioning.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiVersion {
+    String[] supportedVersions() default {"1"};
+}

--- a/backend/spring-routie/src/main/java/routie/global/versioning/domain/ApiVersionParam.java
+++ b/backend/spring-routie/src/main/java/routie/global/versioning/domain/ApiVersionParam.java
@@ -1,0 +1,11 @@
+package routie.global.versioning.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiVersionParam {
+}

--- a/backend/spring-routie/src/main/java/routie/global/versioning/domain/Version.java
+++ b/backend/spring-routie/src/main/java/routie/global/versioning/domain/Version.java
@@ -1,0 +1,38 @@
+package routie.global.versioning.domain;
+
+import java.util.Arrays;
+import java.util.Objects;
+import lombok.Getter;
+
+public record Version(String value) {
+    public Version {
+        if (!isValidVersion(value)) {
+            throw new IllegalArgumentException("Invalid version format: " + value);
+        }
+    }
+
+    public boolean isCompatibleWith(final String... supportedVersions) {
+        return Arrays.asList(supportedVersions).contains(this.value);
+    }
+
+    private boolean isValidVersion(final String version) {
+        return version != null && version.matches("^\\d+(\\.\\d+)*$");
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Version version = (Version) o;
+        return Objects.equals(value, version.value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/global/versioning/domain/Version.java
+++ b/backend/spring-routie/src/main/java/routie/global/versioning/domain/Version.java
@@ -16,7 +16,7 @@ public record Version(String value) {
     }
 
     private boolean isValidVersion(final String version) {
-        return version != null && version.matches("^\\d+(\\.\\d+)*$");
+        return version != null && version.matches("^\\d+(\\.\\d+)?(\\.\\d+)?$");
     }
 
     @Override

--- a/backend/spring-routie/src/main/java/routie/global/versioning/infrastructure/ApiVersionArgumentResolver.java
+++ b/backend/spring-routie/src/main/java/routie/global/versioning/infrastructure/ApiVersionArgumentResolver.java
@@ -1,0 +1,36 @@
+package routie.global.versioning.infrastructure;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import routie.global.versioning.domain.ApiVersionParam;
+import routie.global.versioning.domain.Version;
+
+@Component
+public class ApiVersionArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String DEFAULT_VERSION = "1";
+    private static final String VERSION_PARAM = "version";
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(ApiVersionParam.class)
+                && parameter.getParameterType().equals(Version.class);
+    }
+
+    @Override
+    public Object resolveArgument(final MethodParameter parameter,
+                                  final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest,
+                                  final WebDataBinderFactory binderFactory) {
+
+        String versionValue = webRequest.getParameter(VERSION_PARAM);
+        String resolvedVersion = (versionValue != null && !versionValue.isEmpty())
+                ? versionValue : DEFAULT_VERSION;
+
+        return new Version(resolvedVersion);
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/global/versioning/infrastructure/ApiVersionInterceptor.java
+++ b/backend/spring-routie/src/main/java/routie/global/versioning/infrastructure/ApiVersionInterceptor.java
@@ -1,0 +1,49 @@
+package routie.global.versioning.infrastructure;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import routie.global.versioning.domain.ApiVersion;
+import routie.global.versioning.domain.Version;
+
+@Component
+public class ApiVersionInterceptor implements HandlerInterceptor {
+
+    private static final String DEFAULT_VERSION = "1";
+    private static final String VERSION_PARAM = "version";
+
+    @Override
+    public boolean preHandle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Object handler
+    ) {
+        if (!(handler instanceof final HandlerMethod handlerMethod)) {
+            return true;
+        }
+
+        ApiVersion apiVersion = handlerMethod.getMethodAnnotation(ApiVersion.class);
+        if (apiVersion == null) {
+            return true;
+        }
+
+        Version requestedVersion = getVersionFromRequest(request);
+        String[] supportedVersions = apiVersion.supportedVersions();
+
+        if (!requestedVersion.isCompatibleWith(supportedVersions)) {
+            throw new IllegalArgumentException(); // TODO: 머랭 코드 merge 후 변경
+        }
+
+        return true;
+    }
+
+    private Version getVersionFromRequest(final HttpServletRequest request) {
+        String versionValue = request.getParameter(VERSION_PARAM);
+        String resolvedVersion = (versionValue != null && !versionValue.isEmpty())
+                ? versionValue : DEFAULT_VERSION;
+
+        return new Version(resolvedVersion);
+    }
+}

--- a/backend/spring-routie/src/test/java/routie/global/versioning/ApiVersionSimpleIntegrationTest.java
+++ b/backend/spring-routie/src/test/java/routie/global/versioning/ApiVersionSimpleIntegrationTest.java
@@ -1,0 +1,89 @@
+package routie.global.versioning;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import routie.global.versioning.infrastructure.ApiVersionArgumentResolver;
+import routie.global.versioning.infrastructure.ApiVersionInterceptor;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ApiVersionSimpleIntegrationTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        TestApiVersionController controller = new TestApiVersionController();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .addInterceptors(new ApiVersionInterceptor())
+                .setCustomArgumentResolvers(new ApiVersionArgumentResolver())
+                .build();
+    }
+
+    @Test
+    @DisplayName("버전이 필요하지 않은 엔드포인트는 정상적으로 동작한다")
+    void noVersionRequiredEndpoint() throws Exception {
+        mockMvc.perform(get("/api/test/no-version"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("No version required"));
+    }
+
+    @Test
+    @DisplayName("지원되는 버전으로 요청하면 정상적으로 동작한다")
+    void supportedVersionRequest() throws Exception {
+        mockMvc.perform(get("/api/test/v1")
+                        .param("version", "1"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Current version: 1"));
+    }
+
+    @Test
+    @DisplayName("버전 파라미터가 없으면 기본값 '1'이 사용된다")
+    void defaultVersionRequest() throws Exception {
+        mockMvc.perform(get("/api/test/v1"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Current version: 1"));
+    }
+
+    @Test
+    @DisplayName("지원되지 않는 버전으로 요청하면 예외가 발생한다")
+    void unsupportedVersionRequest() throws Exception {
+        try {
+            mockMvc.perform(get("/api/test/v1-only")
+                    .param("version", "2"));
+        } catch (final Exception e) {
+            // IllegalArgumentException이 발생하는 것을 확인
+            assert e.getCause() instanceof IllegalArgumentException;
+        }
+    }
+
+    @Test
+    @DisplayName("Version 파라미터가 올바르게 주입된다")
+    void versionParameterInjection() throws Exception {
+        mockMvc.perform(get("/api/test/with-version-param")
+                        .param("version", "1.1"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Current version: 1.1"));
+
+        mockMvc.perform(get("/api/test/with-version-param"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Current version: 1"));
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 버전으로 요청하면 예외가 발생한다")
+    void invalidVersionFormatRequest() throws Exception {
+        try {
+            mockMvc.perform(get("/api/test/v1-only")
+                    .param("version", "v1.0"));
+        } catch (final Exception e) {
+            // IllegalArgumentException이 발생하는 것을 확인
+            assert e.getCause() instanceof IllegalArgumentException;
+        }
+    }
+}

--- a/backend/spring-routie/src/test/java/routie/global/versioning/TestApiVersionController.java
+++ b/backend/spring-routie/src/test/java/routie/global/versioning/TestApiVersionController.java
@@ -1,0 +1,29 @@
+package routie.global.versioning;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import routie.global.versioning.domain.ApiVersion;
+import routie.global.versioning.domain.ApiVersionParam;
+import routie.global.versioning.domain.Version;
+
+@RestController
+@RequestMapping("/api/test")
+public class TestApiVersionController {
+
+    @GetMapping("/no-version")
+    public String noVersionEndpoint() {
+        return "No version required";
+    }
+
+    @GetMapping("/v1")
+    public String singleVersion(@ApiVersionParam final Version version) {
+        return "Current version: " + version.value();
+    }
+
+    @GetMapping("/with-version-param")
+    @ApiVersion(supportedVersions = {"1", "1.1", "2"})
+    public String withVersionParam(@ApiVersionParam final Version version) {
+        return "Current version: " + version.value();
+    }
+}

--- a/backend/spring-routie/src/test/java/routie/global/versioning/domain/VersionTest.java
+++ b/backend/spring-routie/src/test/java/routie/global/versioning/domain/VersionTest.java
@@ -1,0 +1,62 @@
+package routie.global.versioning.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class VersionTest {
+
+    @DisplayName("유효한 버전 형식으로 Version 객체를 생성할 수 있다")
+    @ParameterizedTest
+    @ValueSource(strings = {"1", "1.0", "1.2.3", "2.1.0"})
+    void createVersionWithValidFormat(final String versionValue) {
+        // when & then
+        Version version = new Version(versionValue);
+        assertThat(version.value()).isEqualTo(versionValue);
+    }
+
+    @DisplayName("유효하지 않은 버전 형식으로 Version 객체를 생성하면 예외가 발생한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"", "v1.0", "1.0.0.0", "1.0-SNAPSHOT", "1.a.0", "1..0"})
+    void createVersionWithInvalidFormat(final String invalidVersion) {
+        // when & then
+        assertThatThrownBy(() -> new Version(invalidVersion))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid version format");
+    }
+
+    @Test
+    @DisplayName("null 버전으로 Version 객체를 생성하면 예외가 발생한다")
+    void createVersionWithNull() {
+        // when & then
+        assertThatThrownBy(() -> new Version(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid version format");
+    }
+
+    @Test
+    @DisplayName("지원되는 버전 목록에 포함된 버전은 호환 가능하다")
+    void isCompatibleWithSupportedVersions() {
+        // given
+        Version version = new Version("1.2");
+        String[] supportedVersions = {"1", "1.2", "2.0"};
+
+        // when & then
+        assertThat(version.isCompatibleWith(supportedVersions)).isTrue();
+    }
+
+    @Test
+    @DisplayName("지원되는 버전 목록에 포함되지 않은 버전은 호환되지 않는다")
+    void isNotCompatibleWithUnsupportedVersions() {
+        // given
+        Version version = new Version("1.3");
+        String[] supportedVersions = {"1", "1.2", "2.0"};
+
+        // when & then
+        assertThat(version.isCompatibleWith(supportedVersions)).isFalse();
+    }
+}

--- a/backend/spring-routie/src/test/java/routie/global/versioning/infrastructure/ApiVersionArgumentResolverTest.java
+++ b/backend/spring-routie/src/test/java/routie/global/versioning/infrastructure/ApiVersionArgumentResolverTest.java
@@ -1,0 +1,80 @@
+package routie.global.versioning.infrastructure;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+import routie.global.versioning.domain.ApiVersionParam;
+import routie.global.versioning.domain.Version;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApiVersionArgumentResolverTest {
+
+    private ApiVersionArgumentResolver resolver;
+
+    @Mock
+    private MethodParameter methodParameter;
+
+    @Mock
+    private NativeWebRequest webRequest;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new ApiVersionArgumentResolver();
+    }
+
+    @Test
+    @DisplayName("버전 파라미터가 있으면 해당 값으로 Version 객체를 생성한다")
+    void resolveArgumentWithVersionParameter() {
+        // given
+        when(webRequest.getParameter("version")).thenReturn("2.1");
+
+        // when
+        Object result = resolver.resolveArgument(methodParameter, null, webRequest, null);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(Version.class);
+        Version version = (Version) result;
+        assertThat(version.value()).isEqualTo("2.1");
+    }
+
+    @Test
+    @DisplayName("버전 파라미터가 없으면 기본값 '1'로 Version 객체를 생성한다")
+    void resolveArgumentWithoutVersionParameter() {
+        // given
+        when(webRequest.getParameter("version")).thenReturn(null);
+
+        // when
+        Object result = resolver.resolveArgument(methodParameter, null, webRequest, null);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(Version.class);
+        Version version = (Version) result;
+        assertThat(version.value()).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("버전 파라미터가 빈 문자열이면 기본값 '1'로 Version 객체를 생성한다")
+    void resolveArgumentWithEmptyVersionParameter() {
+        // given
+        when(webRequest.getParameter("version")).thenReturn("");
+
+        // when
+        Object result = resolver.resolveArgument(methodParameter, null, webRequest, null);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(Version.class);
+        Version version = (Version) result;
+        assertThat(version.value()).isEqualTo("1");
+    }
+}


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 기존의 API 버저닝 시스템이 없어 API 호환성 관리와 향후 API 변경에 대한 체계적인 관리가 어려운 상황

## To-Be
<!-- 변경 사항 -->
- 쿼리 파라미터를 기반으로 한 API 버저닝 시스템을 도입

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [X] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

`test/java/routie/global/versioning/TestApiVersionController.java`를 보시면 사용 예시를 볼 수 있습니다.

1. Version 도메인 객체
- x.y.z 형식의 semantic versioning 지원
- 유효성 검증 및 호환성 체크 기능 제공
2. `@ApiVersion` 어노테이션 
- 메서드 레벨에서 지원하는 API 버전을 선언
- 다중 버전 지원 (supportedVersions = {"1", "1.1", "2"})
3. `@ApiVersionParam` 어노테이션 
- 컨트롤러 메서드 파라미터에서 버전 정보를 주입받기 위한 어노테이션
4. ApiVersionInterceptor
- 요청된 버전과 지원하는 버전 간의 호환성을 사전 검증
- /api/** 패턴의 요청에 대해 버전 검증 수행
5. ApiVersionArgumentResolver
- 쿼리 파라미터 ?version=1.0에서 Version 객체로 자동 변환
- 버전이 명시되지 않은 경우 기본값 "1" 사용

해당 구현이 나온 이유

- 어노이션으로 버저닝을 하고 있는 api와 그렇지 않은 api 구분 가능
- 비즈니스 로직과 버전 검증 및 추출 로직의 분리
<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #732 