### PR TITLE
refactor: home page UI 리팩터링

### DIFF
--- a/frontend/src/pages/Home/Home.styles.ts
+++ b/frontend/src/pages/Home/Home.styles.ts
@@ -4,6 +4,10 @@ import theme from '@/styles/theme';
 
 const HomepageStyle = css`
   background-color: ${theme.home.gray};
+
+  @media (width <= 970px) {
+    height: auto;
+  }
 `;
 
 const TitleTextStyle = css`
@@ -21,17 +25,32 @@ const VioletTextStyle = css`
 
 const InfoCardsWrapperStyle = css`
   padding: 5rem 0;
+
+  @media (width <= 970px) {
+    flex-direction: column;
+    gap: 3rem;
+  }
+`;
+
+const ButtonWrapperStyle = css`
+  @media (width <= 970px) {
+    flex-direction: column;
+    gap: 2rem;
+    max-width: 40rem;
+  }
 `;
 
 const CreateButtonStyle = css`
   justify-content: center;
+  max-width: 31rem;
   background-color: ${theme.home.violet};
   box-shadow: 0 8px 16px rgb(0 0 0 / 16%);
 `;
 
 const ContinueButtonStyle = css`
   justify-content: center;
-  background-color: white;
+  max-width: 31rem;
+  background-color: ${theme.colors.white};
   box-shadow: 0 8px 16px rgb(0 0 0 / 16%);
 `;
 
@@ -41,6 +60,7 @@ export {
   SubTitleTextStyle,
   VioletTextStyle,
   InfoCardsWrapperStyle,
+  ButtonWrapperStyle,
   CreateButtonStyle,
   ContinueButtonStyle,
 };

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -10,6 +10,7 @@ import reload from '@/assets/icons/reload.svg';
 import theme from '@/styles/theme';
 
 import {
+  ButtonWrapperStyle,
   ContinueButtonStyle,
   CreateButtonStyle,
   HomepageStyle,
@@ -80,7 +81,7 @@ const Home = () => {
               ]}
             />
           </Flex>
-          <Flex gap={8} width="70%">
+          <Flex gap={8} width="70%" css={ButtonWrapperStyle}>
             <Button onClick={handleCreateRoutieSpace} css={CreateButtonStyle}>
               <Flex gap={1.5} padding={1}>
                 <img src={arrowWhite} width={'30rem'} />


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
flex 컴포넌트를 수정하면서 기존 UI가 깨지는 문제를 발견

## To-Be
<!-- 변경 사항 -->
- 기존 UI와 동일하게 수정
- 반응형 추가 -> InfoCard가 깨지는 시점인 970px을 기준으로 반응형을 적용했습니다

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
### 수정된 UI
<img width="1041" height="675" alt="image" src="https://github.com/user-attachments/assets/9a7c7543-9ff8-4bca-bdfe-243565673dc9" />

### 반응형 적용
https://github.com/user-attachments/assets/81f064eb-4774-4b36-8395-b877037bc1a0

## (Optional) Additional Description


Closes #756 
