### PR TITLE
feat: 카카오 로그인 콜백 페이지 구현

### DIFF
--- a/frontend/src/@common/components/Spinner/Spinner.style.ts
+++ b/frontend/src/@common/components/Spinner/Spinner.style.ts
@@ -1,0 +1,26 @@
+import { css, keyframes } from '@emotion/react';
+
+import { SpinnerProps } from './Spinner.types';
+
+const spin = keyframes`
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+`;
+
+const SpinnerStyle = ({
+  size,
+  thickness,
+  speed,
+  color,
+  trackColor,
+}: SpinnerProps) => css`
+  width: ${size}px;
+  height: ${size}px;
+  border: ${thickness}px solid ${trackColor};
+  border-left-color: ${color};
+  border-radius: 50%;
+
+  animation: ${spin} ${speed}s linear infinite;
+`;
+
+export { SpinnerStyle };

--- a/frontend/src/@common/components/Spinner/Spinner.style.ts
+++ b/frontend/src/@common/components/Spinner/Spinner.style.ts
@@ -1,6 +1,6 @@
 import { css, keyframes } from '@emotion/react';
 
-import { SpinnerProps } from './Spinner.types';
+import type { SpinnerProps } from './Spinner.types';
 
 const spin = keyframes`
   0% { transform: rotate(0deg); }

--- a/frontend/src/@common/components/Spinner/Spinner.tsx
+++ b/frontend/src/@common/components/Spinner/Spinner.tsx
@@ -1,0 +1,21 @@
+import { css, keyframes } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+import { SpinnerStyle } from './Spinner.style';
+
+import type { SpinnerProps } from './Spinner.types';
+
+const Spinner = ({
+  size = 36,
+  thickness = 4,
+  speed = 1,
+  color = theme.colors.black,
+  trackColor = theme.colors.gray[50],
+}: SpinnerProps) => {
+  return (
+    <div css={SpinnerStyle({ size, thickness, speed, color, trackColor })} />
+  );
+};
+
+export default Spinner;

--- a/frontend/src/@common/components/Spinner/Spinner.tsx
+++ b/frontend/src/@common/components/Spinner/Spinner.tsx
@@ -1,5 +1,3 @@
-import { css, keyframes } from '@emotion/react';
-
 import theme from '@/styles/theme';
 
 import { SpinnerStyle } from './Spinner.style';

--- a/frontend/src/@common/components/Spinner/Spinner.types.ts
+++ b/frontend/src/@common/components/Spinner/Spinner.types.ts
@@ -1,0 +1,9 @@
+interface SpinnerProps {
+  size?: number;
+  thickness?: number;
+  speed?: number;
+  color?: string;
+  trackColor?: string;
+}
+
+export type { SpinnerProps };

--- a/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
+++ b/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
@@ -1,0 +1,14 @@
+import Flex from '@/@common/components/Flex/Flex';
+import Spinner from '@/@common/components/Spinner/Spinner';
+import Text from '@/@common/components/Text/Text';
+
+const KakaoAuthCallback = () => {
+  return (
+    <Flex direction="column" alignItems="center" height="100vh" gap={2}>
+      <Spinner />
+      <Text variant="title">로그인 중...</Text>
+    </Flex>
+  );
+};
+
+export default KakaoAuthCallback;

--- a/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
+++ b/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
@@ -4,7 +4,7 @@ import Text from '@/@common/components/Text/Text';
 
 const KakaoAuthCallback = () => {
   return (
-    <Flex direction="column" alignItems="center" height="100vh" gap={2}>
+    <Flex direction="column" height="100vh" gap={2}>
       <Spinner />
       <Text variant="title">로그인 중...</Text>
     </Flex>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -7,6 +7,7 @@ import Toast from '@/@common/components/Toast/Toast';
 import ToastProvider from '@/@common/contexts/ToastProvider';
 import { useGoogleAnalytics } from '@/libs/googleAnalytics/hooks/useGoogleAnalytics';
 import Home from '@/pages/Home/Home';
+import KakaoAuthCallback from '@/pages/KakaoAuthCallback/KakaoAuthCallback';
 import VersionInfo from '@/pages/VersionInfo/VersionInfo';
 
 const RoutieSpace = lazy(() => import('@/pages/RoutieSpace/RoutieSpace'));
@@ -34,6 +35,14 @@ const router = createBrowserRouter([
         <Suspense fallback={<div>Loading...</div>}>
           <RoutieSpace />
         </Suspense>
+      </LayoutWithAnalytics>
+    ),
+  },
+  {
+    path: '/auth/kakao/callback',
+    element: (
+      <LayoutWithAnalytics>
+        <KakaoAuthCallback />
       </LayoutWithAnalytics>
     ),
   },


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 로그인 완료 후 토큰을 요청, 리다이렉션 하기 위한 콜백 페이지가 필요

## To-Be
<!-- 변경 사항 -->
- 로그인 완료 후 토큰을 요청, 리다이렉션 하기 위한 콜백 로딩 페이지 구현
- 공통으로 사용할 수 있는 로딩 스피너 컴포넌트 구현

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/aac5f5c6-aa51-4a34-b941-059be78a7976



## (Optional) Additional Description
- `KakaoAuthCallback` 페이지에서 로그인 완료 후 토큰 요청 및 리다이렉션을 처리하면 될 듯 합니다.

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->

close #788 