### PR TITLE
feat: 인증 아키텍쳐 구현

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/authentication/domain/jwt/JwtProcessor.java
+++ b/backend/spring-routie/src/main/java/routie/business/authentication/domain/jwt/JwtProcessor.java
@@ -15,17 +15,17 @@ import routie.business.user.domain.UserRepository;
 @Component
 public class JwtProcessor {
 
+    private final long expiration;
     private final SecretKey secretKey;
-    private final long validityInMilliseconds;
     private final UserRepository userRepository;
 
     public JwtProcessor(
+            @Value("${authentication.jwt.expiration}") final long expiration,
             @Value("${authentication.jwt.secret}") final String secret,
-            @Value("${authentication.jwt.expiration}") final long validityInMilliseconds,
             final UserRepository userRepository
     ) {
+        this.expiration = expiration;
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
-        this.validityInMilliseconds = validityInMilliseconds;
         this.userRepository = userRepository;
     }
 
@@ -35,7 +35,7 @@ public class JwtProcessor {
                 .build();
 
         Date now = new Date();
-        Date expiration = new Date(now.getTime() + validityInMilliseconds);
+        Date expiration = new Date(now.getTime() + this.expiration);
 
         return Jwts.builder()
                 .claims(claims)

--- a/backend/spring-routie/src/main/java/routie/business/authentication/domain/jwt/JwtProcessor.java
+++ b/backend/spring-routie/src/main/java/routie/business/authentication/domain/jwt/JwtProcessor.java
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import routie.business.user.domain.User;
 import routie.business.user.domain.UserRepository;
+import routie.global.exception.domain.BusinessException;
+import routie.global.exception.domain.ErrorCode;
 
 @Component
 public class JwtProcessor {
@@ -45,19 +47,20 @@ public class JwtProcessor {
                 .compact();
     }
 
-    public User getUser(final String token) {
+    public User parseUser(final String jwt) {
         try {
             Claims claims = Jwts.parser()
                     .verifyWith(secretKey)
                     .build()
-                    .parseSignedClaims(token)
+                    .parseSignedClaims(jwt)
                     .getPayload();
 
             String userId = claims.getSubject();
+
             return userRepository.findById(Long.parseLong(userId))
-                    .orElseThrow(() -> new JwtException("Invalid token: user not found"));
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         } catch (final Exception e) {
-            throw new JwtException(e.getMessage());
+            throw new JwtException(e.getMessage(), e);
         }
     }
 }

--- a/backend/spring-routie/src/main/java/routie/business/authentication/ui/argument/AuthenticatedUser.java
+++ b/backend/spring-routie/src/main/java/routie/business/authentication/ui/argument/AuthenticatedUser.java
@@ -1,0 +1,11 @@
+package routie.business.authentication.ui.argument;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedUser {
+}

--- a/backend/spring-routie/src/main/java/routie/business/authentication/ui/argument/config/AuthenticationArgumentConfig.java
+++ b/backend/spring-routie/src/main/java/routie/business/authentication/ui/argument/config/AuthenticationArgumentConfig.java
@@ -1,0 +1,29 @@
+package routie.business.authentication.ui.argument.config;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import routie.business.authentication.ui.argument.interceptor.AuthenticationInterceptor;
+import routie.business.authentication.ui.argument.resolver.AuthenticatedUserArgumentResolver;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthenticationArgumentConfig implements WebMvcConfigurer {
+
+    private final AuthenticationInterceptor authenticationInterceptor;
+    private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(authenticationInterceptor)
+                .addPathPatterns("/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedUserArgumentResolver);
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/business/authentication/ui/argument/interceptor/AuthenticationInterceptor.java
+++ b/backend/spring-routie/src/main/java/routie/business/authentication/ui/argument/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,25 @@
+package routie.business.authentication.ui.argument.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import routie.business.authentication.ui.jwt.JwtParser;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final JwtParser jwtParser;
+
+    @Override
+    public boolean preHandle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Object handler
+    ) {
+        request.setAttribute("jwt", jwtParser.parseFromRequest(request).orElse(null));
+        return true;
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/business/authentication/ui/argument/resolver/AuthenticatedUserArgumentResolver.java
+++ b/backend/spring-routie/src/main/java/routie/business/authentication/ui/argument/resolver/AuthenticatedUserArgumentResolver.java
@@ -1,0 +1,45 @@
+package routie.business.authentication.ui.argument.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import routie.business.authentication.domain.jwt.JwtProcessor;
+import routie.business.authentication.ui.argument.AuthenticatedUser;
+import routie.business.user.domain.User;
+import routie.global.exception.domain.BusinessException;
+import routie.global.exception.domain.ErrorCode;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProcessor jwtProcessor;
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticatedUser.class);
+    }
+
+    @Override
+    public User resolveArgument(
+            final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = Optional.ofNullable(webRequest.getNativeRequest(HttpServletRequest.class))
+                .orElseThrow(() -> new BusinessException(ErrorCode.UNEXPECTED_EXCEPTION));
+
+        String jwt = Optional.ofNullable(request.getAttribute("jwt"))
+                .map(Object::toString)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTHENTICATION_REQUIRED));
+
+        return jwtProcessor.parseUser(jwt);
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/business/authentication/ui/jwt/JwtParser.java
+++ b/backend/spring-routie/src/main/java/routie/business/authentication/ui/jwt/JwtParser.java
@@ -1,0 +1,20 @@
+package routie.business.authentication.ui.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtParser {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final Pattern BEARER_PATTERN = Pattern.compile("^" + BEARER_PREFIX + "(.+)$");
+
+    public Optional<String> parseFromRequest(final HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
+                .filter(header -> BEARER_PATTERN.matcher(header).matches())
+                .map(header -> header.substring(BEARER_PREFIX.length()));
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/global/exception/domain/ErrorCode.java
+++ b/backend/spring-routie/src/main/java/routie/global/exception/domain/ErrorCode.java
@@ -346,6 +346,11 @@ public enum ErrorCode {
             "사용자 인증 제공자는 비어있을 수 없습니다.",
             HttpStatus.BAD_REQUEST
     ),
+    USER_NOT_FOUND(
+            "4100",
+            "해당 사용자를 찾을 수 없습니다.",
+            HttpStatus.NOT_FOUND
+    ),
 
     /**
      * 5XXX: Word domain
@@ -375,6 +380,13 @@ public enum ErrorCode {
     INVALID_JWT(
             "6001",
             "인증 정보가 유효하지 않습니다.",
+            HttpStatus.UNAUTHORIZED
+    ),
+
+    // Authentication
+    AUTHENTICATION_REQUIRED(
+            "6002",
+            "인증이 필요합니다.",
             HttpStatus.UNAUTHORIZED
     ),
 


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
유저 인증 기능은 구현했으나, 로그인 후 인증 정보(jwt)의 존재 여부를 확인하고 유저를 식별할 수단이 존재하지 않음.

## To-Be
<!-- 변경 사항 -->
유저 인증을 위한 아키텍처 구현을 통해, HandlerMethod에서 어노테이션을 통한 파라메터 바인딩을 받을 수 있도록 변경.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


Closes #802 