### PR TITLE
feat: 카카오 로그인 API 연동 및 로그인, 로그아웃 기능 구현

### DIFF
--- a/frontend/src/domains/auth/adapters/authAdapter.ts
+++ b/frontend/src/domains/auth/adapters/authAdapter.ts
@@ -1,0 +1,23 @@
+import {
+  kakaoAccessTokenResponseType,
+  kakaoLoginUriResponseType,
+} from '../types/api.types';
+import { kakaoAccessTokenType, kakaoLoginUriType } from '../types/auth.types';
+
+const getKakaoLoginUriAdapter = (
+  data: kakaoLoginUriResponseType,
+): kakaoLoginUriType => {
+  return {
+    uri: data.uri,
+  };
+};
+
+const getKakaoAccessTokenAdapter = (
+  data: kakaoAccessTokenResponseType,
+): kakaoAccessTokenType => {
+  return {
+    accessToken: data.accessToken,
+  };
+};
+
+export { getKakaoAccessTokenAdapter, getKakaoLoginUriAdapter };

--- a/frontend/src/domains/auth/adapters/authAdapter.ts
+++ b/frontend/src/domains/auth/adapters/authAdapter.ts
@@ -1,23 +1,23 @@
 import type {
-  kakaoAccessTokenResponseType,
-  kakaoLoginUriResponseType,
+  KakaoAccessTokenResponseType,
+  KakaoLoginUriResponseType,
 } from '../types/api.types';
 import type {
-  kakaoAccessTokenType,
-  kakaoLoginUriType,
+  KakaoAccessTokenType,
+  KakaoLoginUriType,
 } from '../types/auth.types';
 
 const getKakaoLoginUriAdapter = (
-  data: kakaoLoginUriResponseType,
-): kakaoLoginUriType => {
+  data: KakaoLoginUriResponseType,
+): KakaoLoginUriType => {
   return {
     uri: data.uri,
   };
 };
 
 const getKakaoAccessTokenAdapter = (
-  data: kakaoAccessTokenResponseType,
-): kakaoAccessTokenType => {
+  data: KakaoAccessTokenResponseType,
+): KakaoAccessTokenType => {
   return {
     accessToken: data.accessToken,
   };

--- a/frontend/src/domains/auth/adapters/authAdapter.ts
+++ b/frontend/src/domains/auth/adapters/authAdapter.ts
@@ -1,8 +1,11 @@
-import {
+import type {
   kakaoAccessTokenResponseType,
   kakaoLoginUriResponseType,
 } from '../types/api.types';
-import { kakaoAccessTokenType, kakaoLoginUriType } from '../types/auth.types';
+import type {
+  kakaoAccessTokenType,
+  kakaoLoginUriType,
+} from '../types/auth.types';
 
 const getKakaoLoginUriAdapter = (
   data: kakaoLoginUriResponseType,

--- a/frontend/src/domains/auth/apis/login.ts
+++ b/frontend/src/domains/auth/apis/login.ts
@@ -5,7 +5,7 @@ import {
   getKakaoLoginUriAdapter,
 } from '../adapters/authAdapter';
 
-const getKakaoLoginUrI = async () => {
+const getKakaoLoginUri = async () => {
   const response = await apiClient.get(
     '/v1/authentication/external/uri?provider=kakao',
   );
@@ -24,4 +24,4 @@ const getKakaoAccessToken = async (code: string) => {
   return getKakaoAccessTokenAdapter(data);
 };
 
-export { getKakaoLoginUrI, getKakaoAccessToken };
+export { getKakaoLoginUri, getKakaoAccessToken };

--- a/frontend/src/domains/auth/apis/login.ts
+++ b/frontend/src/domains/auth/apis/login.ts
@@ -1,0 +1,27 @@
+import { apiClient } from '@/apis';
+
+import {
+  getKakaoAccessTokenAdapter,
+  getKakaoLoginUriAdapter,
+} from '../adapters/authAdapter';
+
+const getKakaoLoginUrI = async () => {
+  const response = await apiClient.get(
+    '/v1/authentication/external/uri?provider=kakao',
+  );
+  const data = await response.json();
+
+  return getKakaoLoginUriAdapter(data);
+};
+
+const getKakaoAccessToken = async (code: string) => {
+  const response = await apiClient.post(`/v1/authentication/external`, {
+    code,
+    provider: 'kakao',
+  });
+  const data = await response.json();
+
+  return getKakaoAccessTokenAdapter(data);
+};
+
+export { getKakaoLoginUrI, getKakaoAccessToken };

--- a/frontend/src/domains/auth/components/LoginModal/LoginModal.tsx
+++ b/frontend/src/domains/auth/components/LoginModal/LoginModal.tsx
@@ -17,7 +17,7 @@ const LoginModal = ({ onClose }: Pick<ModalProps, 'onClose'>) => {
   const { data: kakaoLoginUri } = useKakaoLoginUriQuery();
   const { showToast } = useToastContext();
 
-  const handleLoginButtonClick = async () => {
+  const redirectToKakaoLogin = async () => {
     try {
       if (kakaoLoginUri?.uri) {
         window.open(kakaoLoginUri.uri, '_self');
@@ -29,6 +29,11 @@ const LoginModal = ({ onClose }: Pick<ModalProps, 'onClose'>) => {
         type: 'error',
       });
     }
+  };
+
+  const handleKakaoLinkClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    redirectToKakaoLogin();
   };
 
   return (
@@ -45,9 +50,9 @@ const LoginModal = ({ onClose }: Pick<ModalProps, 'onClose'>) => {
               <Text variant="caption">SNS 계정으로 간편로그인</Text>
               <div css={DividerStyle} />
             </Flex>
-            <button css={KakaoButtonStyle} onClick={handleLoginButtonClick}>
+            <a href="#" onClick={handleKakaoLinkClick} css={KakaoButtonStyle}>
               <img src={kakaoImage} alt="카카오 로그인" />
-            </button>
+            </a>
           </Flex>
         </Flex>
       </div>

--- a/frontend/src/domains/auth/components/LoginModal/LoginModal.tsx
+++ b/frontend/src/domains/auth/components/LoginModal/LoginModal.tsx
@@ -2,7 +2,10 @@ import Flex from '@/@common/components/Flex/Flex';
 import type { ModalProps } from '@/@common/components/Modal/Modal.types';
 import ModalLayout from '@/@common/components/ModalLayout/ModalLayout';
 import Text from '@/@common/components/Text/Text';
+import { useToastContext } from '@/@common/contexts/useToastContext';
 import kakaoImage from '@/assets/images/kakao.png';
+
+import { useKakaoLoginUriQuery } from '../../queries/useAuthQuery';
 
 import {
   LoginModalStyle,
@@ -11,9 +14,21 @@ import {
 } from './LoginModal.styles';
 
 const LoginModal = ({ onClose }: Pick<ModalProps, 'onClose'>) => {
-  const handleKakaoLogin = () => {
-    alert('카카오 로그인이 성공적으로 완료되었습니다!');
-    onClose();
+  const { data: kakaoLoginUri } = useKakaoLoginUriQuery();
+  const { showToast } = useToastContext();
+
+  const handleLoginButtonClick = async () => {
+    try {
+      if (kakaoLoginUri?.uri) {
+        window.open(kakaoLoginUri.uri, '_self');
+      }
+      onClose();
+    } catch (err: any) {
+      showToast({
+        message: err?.message,
+        type: 'error',
+      });
+    }
   };
 
   return (
@@ -30,7 +45,7 @@ const LoginModal = ({ onClose }: Pick<ModalProps, 'onClose'>) => {
               <Text variant="caption">SNS 계정으로 간편로그인</Text>
               <div css={DividerStyle} />
             </Flex>
-            <button css={KakaoButtonStyle} onClick={handleKakaoLogin}>
+            <button css={KakaoButtonStyle} onClick={handleLoginButtonClick}>
               <img src={kakaoImage} alt="카카오 로그인" />
             </button>
           </Flex>

--- a/frontend/src/domains/auth/components/UserMenuButton/UserMenuButton.tsx
+++ b/frontend/src/domains/auth/components/UserMenuButton/UserMenuButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router';
 
 import Icon from '@/@common/components/IconSvg/Icon';
 import UserMenu from '@/domains/auth/components/UserMenu/UserMenu';
@@ -17,6 +18,7 @@ const UserMenuButton = ({
   positioning = 'absolute',
 }: UserMenuButtonProps) => {
   const [isUserInfoOpen, setIsUserInfoOpen] = useState(false);
+  const navigate = useNavigate();
 
   const handleProfileClick = () => {
     if (onClick) {
@@ -27,7 +29,9 @@ const UserMenuButton = ({
   };
 
   const handleLogout = () => {
-    alert('로그아웃 버튼 클릭됨!');
+    localStorage.removeItem('accessToken');
+    navigate('/', { replace: true });
+    return;
   };
 
   const wrapperStyle =

--- a/frontend/src/domains/auth/components/UserMenuButton/UserMenuButton.tsx
+++ b/frontend/src/domains/auth/components/UserMenuButton/UserMenuButton.tsx
@@ -4,6 +4,8 @@ import { useNavigate } from 'react-router';
 import Icon from '@/@common/components/IconSvg/Icon';
 import UserMenu from '@/domains/auth/components/UserMenu/UserMenu';
 
+import { useLogout } from '../../hooks/useLogout';
+
 import {
   UserMenuIconStyle,
   UserMenuButtonWrapperStyle,
@@ -18,7 +20,7 @@ const UserMenuButton = ({
   positioning = 'absolute',
 }: UserMenuButtonProps) => {
   const [isUserInfoOpen, setIsUserInfoOpen] = useState(false);
-  const navigate = useNavigate();
+  const { handleLogout } = useLogout();
 
   const handleProfileClick = () => {
     if (onClick) {
@@ -26,12 +28,6 @@ const UserMenuButton = ({
     } else {
       setIsUserInfoOpen((prev) => !prev);
     }
-  };
-
-  const handleLogout = () => {
-    localStorage.removeItem('accessToken');
-    navigate('/', { replace: true });
-    return;
   };
 
   const wrapperStyle =

--- a/frontend/src/domains/auth/hooks/useLogout.ts
+++ b/frontend/src/domains/auth/hooks/useLogout.ts
@@ -1,0 +1,14 @@
+import { useNavigate } from 'react-router';
+
+const useLogout = () => {
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    localStorage.removeItem('accessToken');
+    navigate('/', { replace: true });
+    return;
+  };
+  return { handleLogout };
+};
+
+export { useLogout };

--- a/frontend/src/domains/auth/queries/key.ts
+++ b/frontend/src/domains/auth/queries/key.ts
@@ -1,0 +1,6 @@
+const loginKey = {
+  kakaoAccessToken: ['kakaoAccessToken'],
+  kakaoLoginUri: ['kakaoLoginUri'],
+};
+
+export { loginKey };

--- a/frontend/src/domains/auth/queries/useAuthQuery.ts
+++ b/frontend/src/domains/auth/queries/useAuthQuery.ts
@@ -2,14 +2,14 @@ import { useNavigate } from 'react-router';
 
 import { useMutation, useQuery } from '@tanstack/react-query';
 
-import { getKakaoAccessToken, getKakaoLoginUrI } from '../apis/login';
+import { getKakaoAccessToken, getKakaoLoginUri } from '../apis/login';
 
 import { loginKey } from './key';
 
 const useKakaoLoginUriQuery = () => {
   return useQuery({
     queryKey: loginKey.kakaoLoginUri,
-    queryFn: () => getKakaoLoginUrI(),
+    queryFn: () => getKakaoLoginUri(),
   });
 };
 

--- a/frontend/src/domains/auth/queries/useAuthQuery.ts
+++ b/frontend/src/domains/auth/queries/useAuthQuery.ts
@@ -20,7 +20,6 @@ const useKakaoLoginMutation = () => {
     mutationKey: loginKey.kakaoAccessToken,
     mutationFn: (code: string) => getKakaoAccessToken(code),
     onSuccess: (data) => {
-      console.log(data);
       localStorage.setItem('accessToken', data.accessToken);
       navigate('/', { replace: true });
     },

--- a/frontend/src/domains/auth/queries/useAuthQuery.ts
+++ b/frontend/src/domains/auth/queries/useAuthQuery.ts
@@ -1,0 +1,33 @@
+import { useNavigate } from 'react-router';
+
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+import { getKakaoAccessToken, getKakaoLoginUrI } from '../apis/login';
+
+import { loginKey } from './key';
+
+const useKakaoLoginUriQuery = () => {
+  return useQuery({
+    queryKey: loginKey.kakaoLoginUri,
+    queryFn: () => getKakaoLoginUrI(),
+  });
+};
+
+const useKakaoLoginMutation = () => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationKey: loginKey.kakaoAccessToken,
+    mutationFn: (code: string) => getKakaoAccessToken(code),
+    onSuccess: (data) => {
+      console.log(data);
+      localStorage.setItem('accessToken', data.accessToken);
+      navigate('/', { replace: true });
+    },
+    onError: () => {
+      console.error('카카오 로그인 실패');
+    },
+  });
+};
+
+export { useKakaoLoginMutation, useKakaoLoginUriQuery };

--- a/frontend/src/domains/auth/types/api.types.ts
+++ b/frontend/src/domains/auth/types/api.types.ts
@@ -1,0 +1,18 @@
+interface kakaoLoginUriResponseType {
+  uri: string;
+}
+
+interface kakaoAccessTokenRequestType {
+  code: string;
+  provider: string;
+}
+
+interface kakaoAccessTokenResponseType {
+  accessToken: string;
+}
+
+export type {
+  kakaoLoginUriResponseType,
+  kakaoAccessTokenRequestType,
+  kakaoAccessTokenResponseType,
+};

--- a/frontend/src/domains/auth/types/api.types.ts
+++ b/frontend/src/domains/auth/types/api.types.ts
@@ -1,18 +1,18 @@
-interface kakaoLoginUriResponseType {
+interface KakaoLoginUriResponseType {
   uri: string;
 }
 
-interface kakaoAccessTokenRequestType {
+interface KakaoAccessTokenRequestType {
   code: string;
   provider: string;
 }
 
-interface kakaoAccessTokenResponseType {
+interface KakaoAccessTokenResponseType {
   accessToken: string;
 }
 
 export type {
-  kakaoLoginUriResponseType,
-  kakaoAccessTokenRequestType,
-  kakaoAccessTokenResponseType,
+  KakaoLoginUriResponseType,
+  KakaoAccessTokenRequestType,
+  KakaoAccessTokenResponseType,
 };

--- a/frontend/src/domains/auth/types/auth.types.ts
+++ b/frontend/src/domains/auth/types/auth.types.ts
@@ -1,0 +1,9 @@
+interface kakaoLoginUriType {
+  uri: string;
+}
+
+interface kakaoAccessTokenType {
+  accessToken: string;
+}
+
+export type { kakaoLoginUriType, kakaoAccessTokenType };

--- a/frontend/src/domains/auth/types/auth.types.ts
+++ b/frontend/src/domains/auth/types/auth.types.ts
@@ -1,9 +1,9 @@
-interface kakaoLoginUriType {
+interface KakaoLoginUriType {
   uri: string;
 }
 
-interface kakaoAccessTokenType {
+interface KakaoAccessTokenType {
   accessToken: string;
 }
 
-export type { kakaoLoginUriType, kakaoAccessTokenType };
+export type { KakaoLoginUriType, KakaoAccessTokenType };

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -5,6 +5,7 @@ import Icon from '@/@common/components/IconSvg/Icon';
 import Text from '@/@common/components/Text/Text';
 import { useModal } from '@/@common/contexts/ModalContext';
 import GoToLoginButton from '@/domains/auth/components/GoToLoginButton/GoToLoginButton';
+import UserMenuButton from '@/domains/auth/components/UserMenuButton/UserMenuButton';
 import theme from '@/styles/theme';
 
 import {
@@ -25,6 +26,7 @@ const Home = () => {
     useRoutieSpaceNavigation();
   const { openModal } = useModal();
   const existingUuid = localStorage.getItem('routieSpaceUuid');
+  const kakaoAccessToken = localStorage.getItem('accessToken');
 
   const handleLoginClick = () => {
     openModal('login');
@@ -33,12 +35,13 @@ const Home = () => {
   return (
     <>
       <Header>
-        <Button
-          width="fit-content"
-          onClick={handleLoginClick}
-        >
-          <Text variant="body">로그인</Text>
-        </Button>
+        {kakaoAccessToken ? (
+          <UserMenuButton userName="바보기린" />
+        ) : (
+          <Button width="fit-content" onClick={handleLoginClick}>
+            <Text variant="body">로그인</Text>
+          </Button>
+        )}
       </Header>
       <Flex
         direction="column"
@@ -92,15 +95,19 @@ const Home = () => {
             />
           </Flex>
           <Flex gap={8} width="80%" css={ButtonWrapperStyle}>
-            <Button onClick={handleCreateRoutieSpace} css={CreateButtonStyle}>
-              <Flex gap={1.5} padding={1}>
-                <Icon name="arrowWhite" size={30} />
-                <Text variant="title" color="white">
-                  동선 만들러가기
-                </Text>
-              </Flex>
-            </Button>
-            {existingUuid && (
+            {kakaoAccessToken ? (
+              <Button onClick={handleCreateRoutieSpace} css={CreateButtonStyle}>
+                <Flex gap={1.5} padding={1}>
+                  <Icon name="arrowWhite" size={30} />
+                  <Text variant="title" color="white">
+                    동선 만들러가기
+                  </Text>
+                </Flex>
+              </Button>
+            ) : (
+              <GoToLoginButton onClick={handleLoginClick} />
+            )}
+            {existingUuid && kakaoAccessToken && (
               <Button
                 onClick={handleReturnToRoutieSpace}
                 css={ContinueButtonStyle}
@@ -113,7 +120,6 @@ const Home = () => {
                 </Flex>
               </Button>
             )}
-            <GoToLoginButton onClick={handleLoginClick} />
           </Flex>
         </Flex>
       </Flex>

--- a/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
+++ b/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
@@ -9,10 +9,9 @@ import { useKakaoLoginMutation } from '@/domains/auth/queries/useAuthQuery';
 const KakaoAuthCallback = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { mutate: kakaoAccessTokenMutate, isError } = useKakaoLoginMutation();
 
   const code = searchParams.get('code');
-
-  const { mutate: kakaoAccessTokenMutate, isError } = useKakaoLoginMutation();
 
   const handleGoHome = () => {
     navigate('/', { replace: true });

--- a/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
+++ b/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
@@ -1,12 +1,47 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+
 import Flex from '@/@common/components/Flex/Flex';
 import Spinner from '@/@common/components/Spinner/Spinner';
 import Text from '@/@common/components/Text/Text';
+import { useKakaoLoginMutation } from '@/domains/auth/queries/useAuthQuery';
 
 const KakaoAuthCallback = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const code = searchParams.get('code');
+
+  const { mutate: kakaoAccessTokenMutate, isError } = useKakaoLoginMutation();
+
+  const handleGoHome = () => {
+    navigate('/', { replace: true });
+  };
+
+  useEffect(() => {
+    const handleKakaoLogin = async () => {
+      if (!code) {
+        navigate('/', { replace: true });
+        return;
+      }
+      kakaoAccessTokenMutate(code);
+    };
+    handleKakaoLogin();
+  }, []);
+
   return (
     <Flex direction="column" height="100vh" gap={2}>
-      <Spinner />
-      <Text variant="title">로그인 중...</Text>
+      {isError ? (
+        <Flex direction="column" alignItems="center" gap={2}>
+          <Text variant="title">로그인 실패</Text>{' '}
+          <button onClick={handleGoHome}>홈으로 가기</button>
+        </Flex>
+      ) : (
+        <>
+          <Spinner />
+          <Text variant="title">로그인 중...</Text>
+        </>
+      )}
     </Flex>
   );
 };

--- a/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
+++ b/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
@@ -20,7 +20,7 @@ const KakaoAuthCallback = () => {
   useEffect(() => {
     const handleKakaoLogin = async () => {
       if (!code) {
-        navigate('/', { replace: true });
+        handleGoHome();
         return;
       }
       kakaoAccessTokenMutate(code);

--- a/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
+++ b/frontend/src/pages/KakaoAuthCallback/KakaoAuthCallback.tsx
@@ -31,8 +31,8 @@ const KakaoAuthCallback = () => {
   return (
     <Flex direction="column" height="100vh" gap={2}>
       {isError ? (
-        <Flex direction="column" alignItems="center" gap={2}>
-          <Text variant="title">로그인 실패</Text>{' '}
+        <Flex direction="column" gap={2}>
+          <Text variant="title">로그인 실패</Text>
           <button onClick={handleGoHome}>홈으로 가기</button>
         </Flex>
       ) : (


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 각자 구현된 백엔드의 로직과 프론트 로직을 합쳐야 하는 상황

## To-Be
<!-- 변경 사항 -->
- 카카로 로그인 관련 타입, 어댑터 정의
- 카카로 로그인 관련 API 요청 함수 추가
- 카카로 로그인 관련 쿼리 키 및 훅 추가
- 로그인 시에 변경되는 UI 구현
- 로그인, 로그아웃 기능 구현

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/a195c4a9-80fc-4377-92a7-4a1a1386ae5a


## (Optional) Additional Description
- 일단 로그아웃 시 토큰 제거 후 홈화면으로 리다이렉트 되도록 구현하였습니다. 이건 추후에 논의를 다시 해봐야 할 것 같습니다.
- 이어서 닉네임 받아오는 로직 추가하면 될 것 같습니다.

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
