### PR TITLE
fix: accessToken 존재 시에만 UserMenuButton 표시

### DIFF
--- a/frontend/src/layouts/MapWithSideSheet/MapWithSideSheet.tsx
+++ b/frontend/src/layouts/MapWithSideSheet/MapWithSideSheet.tsx
@@ -10,12 +10,13 @@ import { ContainerStyle } from './MapWithSideSheet.styles';
 
 const MapWithSideSheet = () => {
   const [open, setOpen] = useState(true);
+  const accessToken = localStorage.getItem('accessToken');
 
   return (
     <Flex>
       <div css={ContainerStyle}>
         <KakaoMap />
-        <UserMenuButton userName="바보기린" />
+        {accessToken && <UserMenuButton userName="바보기린" />}
         <SideSheet open={open} onToggle={() => setOpen((prev) => !prev)} />
       </div>
     </Flex>


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 로그인을 안한 사용자가 공유된 링크로 루티스페이스에 들어오게 되면 로그인한 사용자들만 볼 수 있는 UserMenuButton이 화면에 보이는 문제가 있었습니다. 

## To-Be
<!-- 변경 사항 -->
- 로컬스토리지에 accessToken이 있을 때만 UserMenuButton을 화면에 보여주도록 코드 수정하였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->

close #815 
