### PR TITLE
chore: 루티 스페이스 식별자를 인덱스로 설정

### DIFF
--- a/backend/spring-routie/src/main/resources/db/migration/V7__indexing_routie_space_identifier.sql
+++ b/backend/spring-routie/src/main/resources/db/migration/V7__indexing_routie_space_identifier.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_routie_spaces_identifier ON routie_spaces (identifier);


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
자주 사용하는 루티 스페이스를 식별자로 조회하는 쿼리에서 식별자가 인덱싱이 안되어있어 조회 성능 느림

## To-Be
<!-- 변경 사항 -->
식별자에 인덱스를 걸어 조회 성능 향상

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
this closes #817 
