### PR TITLE
feat: 내 루티 스페이스 목록 조회 API 추가

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
@@ -1,5 +1,6 @@
 package routie.business.routiespace.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +9,7 @@ import routie.business.routiespace.domain.RoutieSpaceIdentifierProvider;
 import routie.business.routiespace.domain.RoutieSpaceRepository;
 import routie.business.routiespace.ui.dto.request.RoutieSpaceUpdateRequest;
 import routie.business.routiespace.ui.dto.response.RoutieSpaceCreateResponse;
+import routie.business.routiespace.ui.dto.response.RoutieSpaceListResponse;
 import routie.business.routiespace.ui.dto.response.RoutieSpaceReadResponse;
 import routie.business.routiespace.ui.dto.response.RoutieSpaceUpdateResponse;
 import routie.business.user.domain.User;
@@ -26,6 +28,12 @@ public class RoutieSpaceService {
         RoutieSpace routieSpace = getRoutieSpaceByRoutieSpaceIdentifier(routieSpaceIdentifier);
 
         return RoutieSpaceReadResponse.from(routieSpace);
+    }
+
+    public RoutieSpaceListResponse getRoutieSpaces(final User user) {
+        List<RoutieSpace> routieSpaces = routieSpaceRepository.findByOwner(user);
+
+        return RoutieSpaceListResponse.from(routieSpaces);
     }
 
     @Transactional

--- a/backend/spring-routie/src/main/java/routie/business/routiespace/domain/RoutieSpaceRepository.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/domain/RoutieSpaceRepository.java
@@ -1,11 +1,15 @@
 package routie.business.routiespace.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import routie.business.user.domain.User;
 
 @Repository
 public interface RoutieSpaceRepository extends JpaRepository<RoutieSpace, Long> {
 
     Optional<RoutieSpace> findByIdentifier(String identifier);
+
+    List<RoutieSpace> findByOwner(User owner);
 }

--- a/backend/spring-routie/src/main/java/routie/business/routiespace/ui/dto/response/RoutieSpaceListResponse.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/ui/dto/response/RoutieSpaceListResponse.java
@@ -1,0 +1,35 @@
+package routie.business.routiespace.ui.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+import routie.business.routiespace.domain.RoutieSpace;
+
+public record RoutieSpaceListResponse(
+        List<RoutieSpaceResponse> routieSpaces
+) {
+
+    public static RoutieSpaceListResponse from(final List<RoutieSpace> routieSpaces) {
+        List<RoutieSpaceResponse> routieSpaceResponses = routieSpaces.stream()
+                .map(RoutieSpaceResponse::from)
+                .toList();
+
+        return new RoutieSpaceListResponse(routieSpaceResponses);
+    }
+
+    public record RoutieSpaceResponse(
+            String id,
+            String name,
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+            LocalDateTime createdTime
+    ) {
+
+        public static RoutieSpaceResponse from(final RoutieSpace routieSpace) {
+            return new RoutieSpaceResponse(
+                    routieSpace.getIdentifier(),
+                    routieSpace.getName(),
+                    routieSpace.getCreatedAt()
+            );
+        }
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/business/routiespace/ui/dto/response/RoutieSpaceListResponse.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/ui/dto/response/RoutieSpaceListResponse.java
@@ -18,7 +18,7 @@ public record RoutieSpaceListResponse(
     }
 
     public record RoutieSpaceResponse(
-            String id,
+            String identifier,
             String name,
             @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
             LocalDateTime createdTime

--- a/backend/spring-routie/src/main/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1.java
@@ -27,9 +27,7 @@ public class RoutieSpaceControllerV1 {
     private final RoutieSpaceService routieSpaceService;
 
     @PostMapping("/routie-spaces")
-    public ResponseEntity<RoutieSpaceCreateResponse> createRoutieSpace(
-            @AuthenticatedUser final User user
-    ) {
+    public ResponseEntity<RoutieSpaceCreateResponse> createRoutieSpace() {
         RoutieSpaceCreateResponse routieSpaceCreateResponse = routieSpaceService.addRoutieSpace();
 
         return ResponseEntity.ok(routieSpaceCreateResponse);

--- a/backend/spring-routie/src/main/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1.java
@@ -10,26 +10,32 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import routie.business.authentication.ui.argument.AuthenticatedUser;
+import routie.business.routiespace.application.RoutieSpaceService;
 import routie.business.routiespace.ui.dto.request.RoutieSpaceUpdateRequest;
 import routie.business.routiespace.ui.dto.response.RoutieSpaceCreateResponse;
+import routie.business.routiespace.ui.dto.response.RoutieSpaceListResponse;
 import routie.business.routiespace.ui.dto.response.RoutieSpaceReadResponse;
 import routie.business.routiespace.ui.dto.response.RoutieSpaceUpdateResponse;
-import routie.business.routiespace.application.RoutieSpaceService;
+import routie.business.user.domain.User;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/routie-spaces")
+@RequestMapping("/v1")
 public class RoutieSpaceControllerV1 {
 
     private final RoutieSpaceService routieSpaceService;
 
-    @PostMapping
-    public ResponseEntity<RoutieSpaceCreateResponse> createRoutieSpace() {
+    @PostMapping("/routie-spaces")
+    public ResponseEntity<RoutieSpaceCreateResponse> createRoutieSpace(
+            @AuthenticatedUser final User user
+    ) {
         RoutieSpaceCreateResponse routieSpaceCreateResponse = routieSpaceService.addRoutieSpace();
+
         return ResponseEntity.ok(routieSpaceCreateResponse);
     }
 
-    @GetMapping("/{routieSpaceIdentifier}")
+    @GetMapping("/routie-spaces/{routieSpaceIdentifier}")
     public ResponseEntity<RoutieSpaceReadResponse> readRoutieSpace(
             @PathVariable final String routieSpaceIdentifier
     ) {
@@ -37,7 +43,16 @@ public class RoutieSpaceControllerV1 {
         return ResponseEntity.ok(routieSpaceReadResponse);
     }
 
-    @PatchMapping("/{routieSpaceIdentifier}")
+    @GetMapping("/my-routie-spaces")
+    public ResponseEntity<RoutieSpaceListResponse> readRoutieSpaces(
+            @AuthenticatedUser final User user
+    ) {
+        RoutieSpaceListResponse routieSpaceListResponse = routieSpaceService.getRoutieSpaces(user);
+
+        return ResponseEntity.ok(routieSpaceListResponse);
+    }
+
+    @PatchMapping("/routie-spaces/{routieSpaceIdentifier}")
     public ResponseEntity<RoutieSpaceUpdateResponse> updateRoutieSpace(
             @PathVariable final String routieSpaceIdentifier,
             @RequestBody @Valid final RoutieSpaceUpdateRequest routieSpaceUpdateRequest

--- a/backend/spring-routie/src/test/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1Test.java
+++ b/backend/spring-routie/src/test/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1Test.java
@@ -10,14 +10,20 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import routie.business.authentication.domain.jwt.JwtProcessor;
 import routie.business.place.ui.dto.request.PlaceCreateRequest;
 import routie.business.place.ui.dto.response.PlaceCreateResponse;
+import routie.business.routiespace.ui.dto.response.RoutieSpaceListResponse;
+import routie.business.user.domain.User;
+import routie.business.user.domain.UserFixture;
+import routie.business.user.domain.UserRepository;
 
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -25,6 +31,12 @@ public class RoutieSpaceControllerV1Test {
 
     @LocalServerPort
     private int port;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtProcessor jwtProcessor;
 
     private String routieSpaceIdentifier;
 
@@ -154,5 +166,46 @@ public class RoutieSpaceControllerV1Test {
         assertThat(places).hasSize(2);
         assertThat(firstPlaceName).isIn("스타벅스 강남점", "투썸플레이스 역삼점");
         assertThat(firstPlaceAddress).isNotNull();
+    }
+
+    @Test
+    @DisplayName("V1 API로 내 루티 스페이스 목록 조회에 성공한다")
+    public void readMyRoutieSpaces() {
+        // 테스트용 사용자 생성 및 토큰 발급
+        User user = UserFixture.emptyUser();
+        userRepository.save(user);
+        String accessToken = jwtProcessor.createJwt(user);
+
+        // given
+        RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .when().log().all()
+                .post("/v2/routie-spaces")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .when().log().all()
+                .post("/v2/routie-spaces")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        // when
+        RoutieSpaceListResponse routieSpaceListResponse = RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .when().log().all()
+                .get("/v1/my-routie-spaces")
+                .then().log().all()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(RoutieSpaceListResponse.class);
+
+        // then
+        assertThat(routieSpaceListResponse.routieSpaces()).hasSize(2);
     }
 }


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
- 내 루티 스페이스 목록을 조회할 수 있는 API 추가
- 헤더의 Access Token을 기반으로 본인의 루티 스페이스만 조회

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #835