### PR TITLE
feat: 내 루티 스페이스 삭제 API 추가

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
@@ -82,6 +82,17 @@ public class RoutieSpaceService {
         return new RoutieSpaceUpdateResponse(routieSpace.getName());
     }
 
+    @Transactional
+    public void deleteRoutieSpace(
+            final String routieSpaceIdentifier,
+            final User user
+    ) {
+        RoutieSpace routieSpace = getRoutieSpaceByRoutieSpaceIdentifier(routieSpaceIdentifier);
+        validateOwner(user, routieSpace);
+
+        routieSpaceRepository.delete(routieSpace);
+    }
+
     private RoutieSpace getRoutieSpaceByRoutieSpaceIdentifier(final String routieSpaceIdentifier) {
         return routieSpaceRepository.findByIdentifier(routieSpaceIdentifier)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROUTIE_SPACE_NOT_EXISTS));

--- a/backend/spring-routie/src/main/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1.java
@@ -3,6 +3,7 @@ package routie.business.routiespace.ui.v1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -61,5 +62,15 @@ public class RoutieSpaceControllerV1 {
         );
 
         return ResponseEntity.ok(routieSpaceUpdateResponse);
+    }
+
+    @DeleteMapping("/routie-spaces/{routieSpaceIdentifier}")
+    public ResponseEntity<Void> deleteRoutieSpace(
+            @PathVariable final String routieSpaceIdentifier,
+            @AuthenticatedUser final User user
+    ) {
+        routieSpaceService.deleteRoutieSpace(routieSpaceIdentifier, user);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/spring-routie/src/test/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1Test.java
+++ b/backend/spring-routie/src/test/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1Test.java
@@ -208,4 +208,43 @@ public class RoutieSpaceControllerV1Test {
         // then
         assertThat(routieSpaceListResponse.routieSpaces()).hasSize(2);
     }
+
+    @Test
+    @DisplayName("V1 API로 루티 스페이스 삭제에 성공한다")
+    public void deleteRoutieSpace() {
+        // 테스트용 사용자 생성 및 토큰 발급
+        User user = UserFixture.emptyUser();
+        userRepository.save(user);
+        String accessToken = jwtProcessor.createJwt(user);
+
+        // given
+        Response createSpaceResponse = RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .when().log().all()
+                .post("/v2/routie-spaces")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().response();
+
+        String newRoutieSpaceIdentifier = createSpaceResponse.jsonPath().getString("routieSpaceIdentifier");
+
+        // when
+        RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .when().log().all()
+                .delete("/v1/routie-spaces/{routieSpaceIdentifier}", newRoutieSpaceIdentifier)
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // then
+        // 삭제된 루티 스페이스 조회 시 404 응답 확인
+        RestAssured
+                .given().log().all()
+                .when().log().all()
+                .get("/v1/routie-spaces/{routieSpaceIdentifier}", newRoutieSpaceIdentifier)
+                .then().log().all()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+    }
 }


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
- 사용자가 본인의 루티 스페이스를 삭제할 수 있는 API 추가
- 헤더의 Access Token을 기반으로 본인의 루티 스페이스만 삭제 가능

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #834