### PR TITLE
fix: 장소 삭제 시 좋아요도 같이 삭제

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/like/domain/PlaceLikeRepository.java
+++ b/backend/spring-routie/src/main/java/routie/business/like/domain/PlaceLikeRepository.java
@@ -8,4 +8,6 @@ import routie.business.place.domain.Place;
 public interface PlaceLikeRepository extends JpaRepository<PlaceLike, Long> {
 
     long countByPlace(Place place);
+
+    void deleteByPlaceId(long placeId);
 }

--- a/backend/spring-routie/src/main/java/routie/business/place/application/PlaceService.java
+++ b/backend/spring-routie/src/main/java/routie/business/place/application/PlaceService.java
@@ -85,6 +85,7 @@ public class PlaceService {
         if (routiePlaceRepository.existsRoutiePlaceByPlaceId(placeId)) {
             throw new BusinessException(ErrorCode.ROUTIE_PLACE_EXIST);
         }
+        placeLikeRepository.deleteByPlaceId(placeId);
         placeRepository.deleteById(placeId);
     }
 

--- a/backend/spring-routie/src/test/java/routie/business/place/ui/v1/PlaceControllerV1Test.java
+++ b/backend/spring-routie/src/test/java/routie/business/place/ui/v1/PlaceControllerV1Test.java
@@ -15,6 +15,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import routie.business.like.domain.PlaceLikeFixture;
+import routie.business.like.domain.PlaceLikeRepository;
 import routie.business.place.domain.Place;
 import routie.business.place.domain.PlaceBuilder;
 import routie.business.place.domain.PlaceRepository;
@@ -38,6 +40,9 @@ public class PlaceControllerV1Test {
     @Autowired
     private RoutieSpaceIdentifierProvider routieSpaceIdentifierProvider;
 
+    @Autowired
+    private PlaceLikeRepository placeLikeRepository;
+
     private Place testPlace;
     private RoutieSpace testRoutieSpace;
 
@@ -56,6 +61,7 @@ public class PlaceControllerV1Test {
                 .routieSpace(testRoutieSpace)
                 .build();
         placeRepository.save(testPlace);
+        placeLikeRepository.save(PlaceLikeFixture.placeLikeForPlace(testPlace));
     }
 
     @Test


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 좋아요가 눌려있는 경우 장소 삭제가 안됨

## To-Be
<!-- 변경 사항 -->
- 장소 삭제 시 좋아요도 같이 삭제함

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #849 