### PR TITLE
fix: 루티 스페이스 삭제 시 장소에 관련된 좋아요 삭제

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/like/domain/PlaceLikeRepository.java
+++ b/backend/spring-routie/src/main/java/routie/business/like/domain/PlaceLikeRepository.java
@@ -1,6 +1,8 @@
 package routie.business.like.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import routie.business.place.domain.Place;
 
@@ -10,4 +12,8 @@ public interface PlaceLikeRepository extends JpaRepository<PlaceLike, Long> {
     long countByPlace(Place place);
 
     void deleteByPlaceId(long placeId);
+
+    @Modifying
+    @Query("DELETE FROM PlaceLike pl WHERE pl.place.routieSpace.id = :routieSpaceId")
+    void deleteByRoutieSpaceId(long routieSpaceId);
 }

--- a/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import routie.business.like.domain.PlaceLikeRepository;
 import routie.business.routiespace.domain.RoutieSpace;
 import routie.business.routiespace.domain.RoutieSpaceIdentifierProvider;
 import routie.business.routiespace.domain.RoutieSpaceRepository;
@@ -23,6 +24,7 @@ public class RoutieSpaceService {
 
     private final RoutieSpaceRepository routieSpaceRepository;
     private final RoutieSpaceIdentifierProvider routieSpaceIdentifierProvider;
+    private final PlaceLikeRepository placeLikeRepository;
 
     public RoutieSpaceReadResponse getRoutieSpace(final String routieSpaceIdentifier) {
         RoutieSpace routieSpace = getRoutieSpaceByRoutieSpaceIdentifier(routieSpaceIdentifier);
@@ -90,6 +92,7 @@ public class RoutieSpaceService {
         RoutieSpace routieSpace = getRoutieSpaceByRoutieSpaceIdentifier(routieSpaceIdentifier);
         validateOwner(user, routieSpace);
 
+        placeLikeRepository.deleteByRoutieSpaceId(routieSpace.getId());
         routieSpaceRepository.delete(routieSpace);
     }
 

--- a/backend/spring-routie/src/test/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1Test.java
+++ b/backend/spring-routie/src/test/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1Test.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import routie.business.authentication.domain.jwt.JwtProcessor;
+import routie.business.place.domain.PlaceFixture;
 import routie.business.place.ui.dto.request.PlaceCreateRequest;
 import routie.business.place.ui.dto.response.PlaceCreateResponse;
 import routie.business.routiespace.ui.dto.response.RoutieSpaceListResponse;
@@ -228,6 +229,35 @@ public class RoutieSpaceControllerV1Test {
                 .extract().response();
 
         String newRoutieSpaceIdentifier = createSpaceResponse.jsonPath().getString("routieSpaceIdentifier");
+
+        final PlaceCreateRequest placeCreateRequest = new PlaceCreateRequest(
+                "testPlaceId",
+                PlaceFixture.anyName(),
+                PlaceFixture.anyRoadAddressName(),
+                PlaceFixture.anyAddressName(),
+                PlaceFixture.anyLongitude(),
+                PlaceFixture.anyLatitude()
+        );
+        final PlaceCreateResponse placeCreateResponse = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(placeCreateRequest)
+                .when()
+                .post("/v1/routie-spaces/{routieSpaceIdentifier}/places", newRoutieSpaceIdentifier)
+                .then().log().all()
+                .log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(PlaceCreateResponse.class);
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .when()
+                .post(
+                        "/v1/routie-spaces/{routieSpaceIdentifier}/places/{placeId}/likes",
+                        newRoutieSpaceIdentifier,
+                        placeCreateResponse.id()
+                );
 
         // when
         RestAssured


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 루티 스페이스 삭제 시 오류 발생

## To-Be
<!-- 변경 사항 -->
- 관련된 좋아요 삭제로 해결

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #854 