### PR TITLE
fix: 루티 스페이스를 삭제할 수 없는 문제 해결

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/routie/domain/Routie.java
+++ b/backend/spring-routie/src/main/java/routie/business/routie/domain/Routie.java
@@ -2,7 +2,6 @@ package routie.business.routie.domain;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -22,8 +21,11 @@ import routie.global.exception.domain.ErrorCode;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Routie {
 
-    @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, orphanRemoval = true)
-    @JoinColumn(name = "routie_space_id", nullable = false)
+    @OneToMany(
+            mappedBy = "routieSpace",
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
+            orphanRemoval = true
+    )
     private List<RoutiePlace> routiePlaces = new ArrayList<>();
 
     public static Routie empty() {

--- a/backend/spring-routie/src/main/java/routie/business/routie/domain/RoutiePlace.java
+++ b/backend/spring-routie/src/main/java/routie/business/routie/domain/RoutiePlace.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import routie.business.place.domain.Place;
+import routie.business.routiespace.domain.RoutieSpace;
 import routie.global.exception.domain.BusinessException;
 import routie.global.exception.domain.ErrorCode;
 
@@ -49,6 +50,9 @@ public class RoutiePlace {
     @JoinColumn(name = "place_id", nullable = false)
     private Place place;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private RoutieSpace routieSpace;
+
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -59,6 +63,7 @@ public class RoutiePlace {
         this.id = null;
         this.sequence = sequence;
         this.place = place;
+        this.routieSpace = place.getRoutieSpace();
         this.createdAt = null;
     }
 


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
루티 스페이스를 제거할 수 없었음.

```
[UNEXPECTED] could not execute statement [Column 'place_id' cannot be null] [update routie_places set created_at=?,place_id=?,sequence=? where id=?]; SQL [update routie_places set created_at=?,place_id=?,sequence=? where id=?]; constraint [null]
```

## To-Be
<!-- 변경 사항 -->
양방향 매핑 적용으로 긴급 해결 (과정은 추후 작성)

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

Closes #858 