### PR TITLE
fix: 홈 화면에서 사용자 정보 조회 누락으로 로그인 후에도 로그인 버튼이 유지되는 문제 수정

### DIFF
--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -1,12 +1,16 @@
+import { useEffect } from 'react';
+
 import Button from '@/@common/components/Button/Button';
 import Flex from '@/@common/components/Flex/Flex';
 import Header from '@/@common/components/Header/Header';
 import Icon from '@/@common/components/IconSvg/Icon';
 import Text from '@/@common/components/Text/Text';
 import { useModal } from '@/@common/contexts/ModalContext';
+import { useToastContext } from '@/@common/contexts/useToastContext';
 import { getAccessToken } from '@/@common/utils/getAccessToken';
 import GoToLoginButton from '@/domains/auth/components/GoToLoginButton/GoToLoginButton';
 import UserMenuButton from '@/domains/auth/components/UserMenuButton/UserMenuButton';
+import { useUserQuery } from '@/domains/auth/queries/useAuthQuery';
 import theme from '@/styles/theme';
 
 import {
@@ -26,7 +30,9 @@ const Home = () => {
   const { handleCreateRoutieSpace, handleMoveToManageRoutieSpace } =
     useRoutieSpaceNavigation();
   const { openModal } = useModal();
-  
+  const { showToast } = useToastContext();
+  const { error } = useUserQuery();
+
   const accessToken = getAccessToken();
   const role = localStorage.getItem('role');
   const isAuthenticatedUser = Boolean(accessToken) && role === 'USER';
@@ -34,6 +40,16 @@ const Home = () => {
   const handleLoginClick = () => {
     openModal('socialLogin');
   };
+
+  useEffect(() => {
+    if (error) {
+      showToast({
+        message: '사용자 정보를 불러오는 중 에러가 발생했습니다.',
+        type: 'error',
+      });
+      console.error(error);
+    }
+  }, [error, showToast]);
 
   return (
     <>


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 홈 화면(Home)에서 사용자 정보(nickname, role) 를 조회하는 로직이 없었음
- 이로 인해 카카오 로그인 후에도 로그인 버튼이 유지되고, 사용자 메뉴가 표시되지 않음
- 로그인 성공 후 UI가 업데이트되지 않아 사용자 입장에서 로그인이 안 된 것처럼 보이는 문제 발생

## To-Be
<!-- 변경 사항 -->
- useUserQuery를 활용해 홈 화면에서 사용자 정보를 불러오도록 수정
- 사용자 정보 조회 실패 시 Toast로 에러 피드백 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
Closes #882 
