### PR TITLE
fix: 루티 스페이스 삭제 시 오류 해결

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/place/domain/PlaceRepository.java
+++ b/backend/spring-routie/src/main/java/routie/business/place/domain/PlaceRepository.java
@@ -2,6 +2,9 @@ package routie.business.place.domain;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import routie.business.routiespace.domain.RoutieSpace;
 
@@ -11,4 +14,8 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     Optional<Place> findByIdAndRoutieSpace(Long id, RoutieSpace routieSpace);
 
     boolean existsByIdAndRoutieSpace(Long id, RoutieSpace routieSpace);
+
+    @Modifying
+    @Query("DELETE FROM PlaceHashtag ph WHERE ph.place.routieSpace = :routieSpace")
+    void deletePlaceHashtagsByRoutieSpace(@Param("routieSpace") RoutieSpace routieSpace);
 }

--- a/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import routie.business.hashtag.domain.HashtagRepository;
 import routie.business.like.domain.PlaceLikeRepository;
 import routie.business.participant.domain.User;
+import routie.business.place.domain.PlaceRepository;
 import routie.business.routiespace.domain.RoutieSpace;
 import routie.business.routiespace.domain.RoutieSpaceIdentifierProvider;
 import routie.business.routiespace.domain.RoutieSpaceRepository;
@@ -28,6 +29,7 @@ public class RoutieSpaceService {
     private final RoutieSpaceIdentifierProvider routieSpaceIdentifierProvider;
     private final PlaceLikeRepository placeLikeRepository;
     private final HashtagRepository hashtagRepository;
+    private final PlaceRepository placeRepository;
 
     public RoutieSpaceReadResponse getRoutieSpace(final String routieSpaceIdentifier) {
         final RoutieSpace routieSpace = getRoutieSpaceByRoutieSpaceIdentifier(routieSpaceIdentifier);
@@ -95,7 +97,7 @@ public class RoutieSpaceService {
         final RoutieSpace routieSpace = getRoutieSpaceByRoutieSpaceIdentifier(routieSpaceIdentifier);
         validateOwner(user, routieSpace);
 
-        routieSpace.getPlaces().forEach(place -> place.getPlaceHashtags().clear());
+        placeRepository.deletePlaceHashtagsByRoutieSpace(routieSpace);
         hashtagRepository.deleteByRoutieSpace(routieSpace);
         placeLikeRepository.deleteByRoutieSpace(routieSpace);
         routieSpaceRepository.delete(routieSpace);

--- a/backend/spring-routie/src/test/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1Test.java
+++ b/backend/spring-routie/src/test/java/routie/business/routiespace/ui/v1/RoutieSpaceControllerV1Test.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+
 import java.util.List;
 import java.util.regex.Pattern;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -310,10 +312,28 @@ public class RoutieSpaceControllerV1Test {
                 List.of("카페", "조용함")
         );
 
+        final PlaceCreateRequestV2 placeCreateRequest2 = new PlaceCreateRequestV2(
+                "testPlaceId2",
+                "스타벅스 강남점",
+                "서울시 강남구 테헤란로 123",
+                "서울시 강남구 역삼동 123-45",
+                127.0276,
+                37.4979,
+                List.of("술집", "조용함")
+        );
+
         RestAssured
                 .given()
                 .contentType(ContentType.JSON)
                 .body(placeCreateRequest)
+                .when()
+                .post("/v2/routie-spaces/{routieSpaceIdentifier}/places", newRoutieSpaceIdentifier)
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+        RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(placeCreateRequest2)
                 .when()
                 .post("/v2/routie-spaces/{routieSpaceIdentifier}/places", newRoutieSpaceIdentifier)
                 .then().log().all()


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 루티 스페이스 삭제 시 해시태그가 걸린 장소가 존재하면 삭제가 안되는 문제 발생
  - `RoutieSpace` 삭제 시 `RoutieSpace`의 `Hashtag`를 삭제하는 과정에서 `PlaceHashtag`가 참조하는 `Hashtag`가 null이 되는 문제

## To-Be
<!-- 변경 사항 -->
- `RoutieSpace` 삭제 시 `RoutieSpace`내부의 `Place`의 `PlaceHashtag`를 clear 함수를 통해 삭제한 뒤 `RoutieSpace`의 `Hashtag`를 삭제

## Check List
- [X] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
`orphanRemoval`을 통해서 `List<PlaceHashtag>`를 비워 삭제를 했습니다. 이유는 다음과 같습니다.
- 중간 테이블인 `PlaceHashtag`를 먼저 삭제해야하는데 하나의 패키지에는 하나의 `Repository`만 만들자는 컨벤션이 존재
- `PlaceRepository`에 `deletePlaceHashtagByRoutieSpace(RoutieSpace routieSpace)` 메서드를 만들어 커스텀 쿼리를 작성할 수 있지만 팀원들의 선호가 불분명

팀원들이 동의한다면 커스텀 쿼리를 작성하는 것을 제안하고 싶은데 의견을 알려주세요. 아래는 그 이유입니다.
- orphanRemoval에 의존적인 코드
- 의미있는 메서드 명
- N+1 문제

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #914 