### PR TITLE
fix: 사이드바가 닫혀있을 때 TabButton 클릭 시 작동되지 않는 문제 수정

### DIFF
--- a/frontend/src/pages/RoutieSpace/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/pages/RoutieSpace/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Flex from '@/@common/components/Flex/Flex';
 import Icon from '@/@common/components/IconSvg/Icon';
@@ -21,7 +21,7 @@ import { CONTENT_WIDTH, SIDEBAR_WIDTH_CLOSED } from './width';
 import type { SidebarProps } from './Sidebar.types';
 
 const Sidebar = ({ isOpen, handleToggle }: SidebarProps) => {
-  const [activeTab, setActiveTab] = useState<'place' | 'route'>('place');
+  const [activeTab, setActiveTab] = useState<'place' | 'route' | null>('place');
   const { handleMoveToHome } = useRoutieSpaceNavigation();
   const { showToast } = useToastContext();
   const shareLink = useShareLink();
@@ -35,6 +35,19 @@ const Sidebar = ({ isOpen, handleToggle }: SidebarProps) => {
       showToast({ type: 'error', message: '링크 복사를 실패하였습니다.' });
     }
   };
+
+  const handleTabClick = (tab: 'place' | 'route') => {
+    if (!isOpen) {
+      handleToggle();
+    }
+    setActiveTab(tab);
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      setActiveTab(null);
+    }
+  }, [isOpen]);
 
   return (
     <div css={SidebarContainerStyle(isOpen)}>
@@ -57,13 +70,13 @@ const Sidebar = ({ isOpen, handleToggle }: SidebarProps) => {
           <TabButton
             name="장소"
             icon={activeTab === 'place' ? 'placeTabSelect' : 'placeTab'}
-            onClick={() => setActiveTab('place')}
+            onClick={() => handleTabClick('place')}
             isActive={activeTab === 'place'}
           />
           <TabButton
             name="동선"
             icon={activeTab === 'route' ? 'routeTabSelect' : 'routeTab'}
-            onClick={() => setActiveTab('route')}
+            onClick={() => handleTabClick('route')}
             isActive={activeTab === 'route'}
           />
           <TabButton


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
사이드바가 닫힌 상태에서 TabButton 클릭 시에도 장소, 동선 탭으로 이동하도록 수정하였습니다. 


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/2708d6a8-e7a9-4daa-98c5-dca647d6d1af



## (Optional) Additional Description

공유 탭은 오거스가 구현할 것 같은데, 공유탭도 추가해둘까 하다가 침범하는 것 같아 우선 share 탭은 두지 않았습니다! 🙇‍♀️

Closes #922 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사이드바 탭 전환 시 사이드바가 자동으로 열리는 기능 추가
  * 사이드바 닫을 때 탭 상태가 자동으로 초기화되도록 개선
  * 루트/장소 뷰 간 전환이 보다 직관적으로 작동하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->