### PR TITLE
fix: 루티스페이스를 나갈 때 세션스토리지 초기화

### DIFF
--- a/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
+++ b/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
@@ -5,6 +5,7 @@ import { useModal } from '@/@common/contexts/ModalContext';
 import { useToastContext } from '@/@common/contexts/useToastContext';
 import { useToggle } from '@/@common/hooks/useToggle';
 import { getAccessToken } from '@/@common/utils/getAccessToken';
+import { sessionStorageUtils } from '@/@common/utils/sessionStorage';
 import UserMenuButton from '@/domains/auth/components/UserMenuButton/UserMenuButton';
 import { useUserQuery } from '@/domains/auth/queries/useAuthQuery';
 import KakaoMap from '@/domains/maps/components/KakaoMap/KakaoMap';
@@ -44,6 +45,12 @@ const RoutieSpace = () => {
       console.error(error);
     }
   }, [error, showToast]);
+
+  useEffect(() => {
+    return () => {
+      sessionStorageUtils.remove('selectedHashtags');
+    };
+  }, []);
 
   return (
     <HashtagFilterProvider>


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
새롭게 만든 루티 스페이스에서 장소와 해시태그를 추가했는데, 내 동선 목록에서 새롭게 루티 스페이스를 만들거나 이전에 만들었던 루티스페이스에 들어가도 처음 태그들이 여전히 보이는 문제 발견

## To-Be
<!-- 변경 사항 -->
루티 스페이스를 새롭게 들어올 때 (=마운트될 때), 해시태그 세션 스토리지를 제거하도록 하여 버그 수정


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/74866939-8a1f-4b9a-a848-b9078c797ad3

## (Optional) Additional Description

Closes #927 