### PR TITLE
fix: 장소 추가 시 이전 해시태그 선택 상태가 유지되는 문제 수정

### DIFF
--- a/frontend/src/domains/places/contexts/HashtagFilterProvider.tsx
+++ b/frontend/src/domains/places/contexts/HashtagFilterProvider.tsx
@@ -1,10 +1,10 @@
-import { useHashtagSelection } from '@/domains/places/hooks/useHashtagSelection';
+import { useHashtagFilter } from '@/domains/places/hooks/useHashtagFilter';
 
 import { HashtagFilterContext } from './useHashtagFilterContext';
 
 const HashtagFilterProvider = ({ children }: { children: React.ReactNode }) => {
   const { selectedTags: selectedHashtags, handleToggleTag: updateHashtagSelection } =
-    useHashtagSelection();
+    useHashtagFilter();
 
   return (
     <HashtagFilterContext.Provider value={{ selectedHashtags, updateHashtagSelection }}>

--- a/frontend/src/domains/places/hooks/useHashtag.ts
+++ b/frontend/src/domains/places/hooks/useHashtag.ts
@@ -12,7 +12,7 @@ const useHashtag = (initialTags?: string[]) => {
 
   const [inputValue, setInputValue] = useState('');
   const { selectedTags, handleToggleTag, resetSelectedTags, addTag } =
-    useHashtagSelection(initialTags, false);
+    useHashtagSelection(initialTags);
   const { data: hashtagsData, isError, error } = useHashtagsQuery();
   const previousTags = hashtagsData?.hashtags || [];
   const { showToast } = useToastContext();

--- a/frontend/src/domains/places/hooks/useHashtagFilter.ts
+++ b/frontend/src/domains/places/hooks/useHashtagFilter.ts
@@ -1,13 +1,17 @@
 import { useEffect, useState } from 'react';
 
-const useHashtagSelection = (initialTags?: string[]) => {
-  const [selectedTags, setSelectedTags] = useState<string[]>(initialTags || []);
+import { sessionStorageUtils } from '@/@common/utils/sessionStorage';
+
+const STORAGE_KEY = 'selectedHashtags';
+
+const useHashtagFilter = () => {
+  const [selectedTags, setSelectedTags] = useState<string[]>(() => {
+    return sessionStorageUtils.get(STORAGE_KEY, []);
+  });
 
   useEffect(() => {
-    if (initialTags) {
-      setSelectedTags(initialTags);
-    }
-  }, [initialTags]);
+    sessionStorageUtils.set(STORAGE_KEY, selectedTags);
+  }, [selectedTags]);
 
   const handleToggleTag = (tag: string) => {
     if (selectedTags.includes(tag)) {
@@ -21,18 +25,11 @@ const useHashtagSelection = (initialTags?: string[]) => {
     setSelectedTags([]);
   };
 
-  const addTag = (tag: string) => {
-    if (!selectedTags.includes(tag)) {
-      setSelectedTags((prev) => [tag, ...prev]);
-    }
-  };
-
   return {
     selectedTags,
     handleToggleTag,
     resetSelectedTags,
-    addTag,
   };
 };
 
-export { useHashtagSelection };
+export { useHashtagFilter };


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
장소를 추가할 때 이전에 선택했던 해시태그가 다음 장소 추가 시에도 선택된 상태로 남아있는 문제가 발생했습니다.

`useHashtagSelection` 훅이 두 가지 다른 용도로 사용되고 있었습니다:

1. 지도 필터링 (HashtagFilterProvider) - sessionStorage 사용 필요
2. 장소 추가 시 해시태그 선택 (useHashtag) - sessionStorage 사용하면 안 됨

두 용도 모두 같은 sessionStorage 키(`'selectedHashtags'`)를 공유하여 충돌이 발생했습니다.

기존에 문제가 있던 dev 영상입니다.

https://github.com/user-attachments/assets/77c59811-c5e5-4f5e-a1b7-3f14c78d863a


## To-Be
<!-- 변경 사항 -->
- 장소 추가: 매번 빈 상태에서 해시태그 선택 시작
- 지도 필터링: 기존처럼 sessionStorage 사용하여 새로고침 후에도 필터 상태 유지

수정 후 로컬 영상입니다. (장소 추가가 완료되면 세션 스토리지 리셋됩니다)

https://github.com/user-attachments/assets/e17fad20-50d2-42d0-8a64-6800a325b85b


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

이런저런 문제가 많네요..... 더 분발하겟슴다... 🙇‍♀️

## (Optional) Additional Description

Closes #939 
