### PR TITLE
fix: 동선에 추가된 장소 카드에서 삭제 버튼이 활성화되어 있는 문제 수정

### DIFF
--- a/frontend/src/domains/places/components/PlaceCard/PlaceCard.stories.tsx
+++ b/frontend/src/domains/places/components/PlaceCard/PlaceCard.stories.tsx
@@ -47,6 +47,9 @@ export const Default: Story = {
     onLike: (placeId: number) => {
       alert(`장소 ${placeId} 좋아요`);
     },
+    onDeleteRoutie: async (placeId: number) => {
+      alert(`장소 ${placeId} 동선에서 삭제`);
+    },
   },
 };
 

--- a/frontend/src/domains/places/components/PlaceCard/PlaceCard.tsx
+++ b/frontend/src/domains/places/components/PlaceCard/PlaceCard.tsx
@@ -21,10 +21,15 @@ const PlaceCard = ({
   onLike,
   onCancelEdit,
   onUpdateHashtags,
+  onDeleteRoutie,
   ...props
 }: PlaceCardProps) => {
   const handlePlaceSelect = async () => {
     await onSelect(props.id, selected);
+  };
+
+  const handleDeleteRoutie = async () => {
+    await onDeleteRoutie(props.id);
   };
 
   return (
@@ -80,14 +85,13 @@ const PlaceCard = ({
           </Flex>
         </Flex>
         <Button
-          variant="primary"
-          onClick={handlePlaceSelect}
-          disabled={selected}
-          padding="0.6rem 1.2rem"
+          variant={selected ? 'dangerSecondary' : 'primary'}
+          onClick={selected ? handleDeleteRoutie : handlePlaceSelect}
+          padding="0.6rem 0.8rem"
           width="10rem"
         >
-          <Text variant="caption" color={theme.colors.white}>
-            동선에 추가
+          <Text variant="label" color={theme.colors.white}>
+            {selected ? '동선에서 삭제' : '동선에 추가'}
           </Text>
         </Button>
       </Flex>

--- a/frontend/src/domains/places/components/PlaceCard/PlaceCard.types.ts
+++ b/frontend/src/domains/places/components/PlaceCard/PlaceCard.types.ts
@@ -10,6 +10,7 @@ interface PlaceCardProps extends PlaceWithLikeType {
   onEdit: (placeId: number) => void | Promise<void>;
   onCancelEdit?: () => void;
   onUpdateHashtags?: (hashtags: string[]) => Promise<void>;
+  onDeleteRoutie: (placeId: number) => Promise<void>;
 }
 
 export type { PlaceCardProps };

--- a/frontend/src/pages/RoutieSpace/components/PlaceView/PlaceView.tsx
+++ b/frontend/src/pages/RoutieSpace/components/PlaceView/PlaceView.tsx
@@ -22,7 +22,7 @@ const PlaceView = () => {
     usePlaceList();
   const { handleLikePlace, handleDeleteLikePlace, likedPlaceIds } =
     usePlaceLikes();
-  const { routieIdList, handleAddRoutie } = useRoutieList();
+  const { routieIdList, handleAddRoutie, handleDeleteRoutie } = useRoutieList();
   const { openModal } = useModal();
   const { selectedHashtags } = useHashtagFilterContext();
   const [editingPlaceId, setEditingPlaceId] = useState<number | null>(null);
@@ -145,6 +145,7 @@ const PlaceView = () => {
                   isEditing={isEditing}
                   onSelect={handlePlaceSelect}
                   onDelete={handlePlaceDelete}
+                  onDeleteRoutie={handleDeleteRoutie}
                   onLike={
                     liked ? handleUnlikeButtonClick : handleLikeButtonClick
                   }


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
- 동선에 추가된 장소 삭제 버튼 비활성화
<img width="485" height="133" alt="image" src="https://github.com/user-attachments/assets/321c9210-a212-4be2-81ef-3bd5e002f908" />

- 장소 카드에서도 동선에서 제거할 수 있는 기능 부여

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description



Closes #963 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 선택된 장소를 동선에서 삭제할 수 있는 기능이 추가되었습니다. 장소 카드의 버튼이 동선 추가와 삭제 기능 간 토글로 작동하며, 선택된 항목은 클릭 시 동선에서 제거됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->