### PR TITLE
fix: 루티 스페이스 삭제 시 참조하는 Guest를 삭제

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/participant/domain/GuestRepository.java
+++ b/backend/spring-routie/src/main/java/routie/business/participant/domain/GuestRepository.java
@@ -1,10 +1,14 @@
 package routie.business.participant.domain;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import routie.business.routiespace.domain.RoutieSpace;
+
+import java.util.Optional;
 
 public interface GuestRepository extends JpaRepository<Guest, Long> {
     boolean existsByNicknameAndRoutieSpaceId(String nickname, Long routieSpaceId);
 
     Optional<Guest> findByNicknameAndRoutieSpaceId(String nickname, Long RoutieSpaceId);
+
+    void deleteByRoutieSpace(RoutieSpace routieSpace);
 }

--- a/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
@@ -1,12 +1,11 @@
 package routie.business.routiespace.application;
 
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import routie.business.hashtag.domain.HashtagRepository;
 import routie.business.like.domain.PlaceLikeRepository;
+import routie.business.participant.domain.GuestRepository;
 import routie.business.participant.domain.User;
 import routie.business.place.domain.PlaceRepository;
 import routie.business.routiespace.domain.RoutieSpace;
@@ -20,6 +19,8 @@ import routie.business.routiespace.ui.dto.response.RoutieSpaceUpdateResponse;
 import routie.global.exception.domain.BusinessException;
 import routie.global.exception.domain.ErrorCode;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -30,6 +31,7 @@ public class RoutieSpaceService {
     private final PlaceLikeRepository placeLikeRepository;
     private final HashtagRepository hashtagRepository;
     private final PlaceRepository placeRepository;
+    private final GuestRepository guestRepository;
 
     public RoutieSpaceReadResponse getRoutieSpace(final String routieSpaceIdentifier) {
         final RoutieSpace routieSpace = getRoutieSpaceByRoutieSpaceIdentifier(routieSpaceIdentifier);
@@ -100,6 +102,7 @@ public class RoutieSpaceService {
         placeRepository.deletePlaceHashtagsByRoutieSpace(routieSpace);
         hashtagRepository.deleteByRoutieSpace(routieSpace);
         placeLikeRepository.deleteByRoutieSpace(routieSpace);
+        guestRepository.deleteByRoutieSpace(routieSpace);
         routieSpaceRepository.delete(routieSpace);
     }
 


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 루티 스페이스에 게스트가 존재하면 삭제가 불가능 함

## To-Be
<!-- 변경 사항 -->
- 루티 스페이스 삭제 요청 시 연관된 게스트까지 삭제

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


Closes #974 

