### PR TITLE
fix: 장소 카카오 아이디 부여가 SSE에는 반영되지 않던 문제 수정

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/place/ui/PlaceEventBroadcaster.java
+++ b/backend/spring-routie/src/main/java/routie/business/place/ui/PlaceEventBroadcaster.java
@@ -1,4 +1,4 @@
-package routie.business.place.ui.event;
+package routie.business.place.ui;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -31,7 +31,7 @@ public class PlaceEventBroadcaster {
         final String routieSpaceIdentifier = placeUpdateEvent.getRoutieSpaceIdentifier();
         final SsePlaceUpdateResponse placeUpdateResponse = SsePlaceUpdateResponse.createWithPlaceListResponseV2(
                 placeUpdateEvent.getPlaceId(),
-                placeService.readPlacesV2(routieSpaceIdentifier)
+                placeService.readPlacesV3(routieSpaceIdentifier)
         );
         final SseMessage message = new SseMessage("PLACE_UPDATED", placeUpdateResponse);
         routieSpaceSseEmitters.broadcast(routieSpaceIdentifier, message);
@@ -43,7 +43,7 @@ public class PlaceEventBroadcaster {
         final String routieSpaceIdentifier = placeDeleteEvent.getRoutieSpaceIdentifier();
         final SsePlaceDeleteResponse placeDeleteResponse = SsePlaceDeleteResponse.createWithPlaceListResponseV2(
                 placeDeleteEvent.getPlaceId(),
-                placeService.readPlacesV2(routieSpaceIdentifier)
+                placeService.readPlacesV3(routieSpaceIdentifier)
         );
         final SseMessage message = new SseMessage("PLACE_DELETED", placeDeleteResponse);
         routieSpaceSseEmitters.broadcast(routieSpaceIdentifier, message);
@@ -55,7 +55,7 @@ public class PlaceEventBroadcaster {
         final String routieSpaceIdentifier = placeCreateEvent.getRoutieSpaceIdentifier();
         final SsePlaceCreateResponse placeCreateResponse = SsePlaceCreateResponse.createWithPlaceListResponseV2(
                 placeCreateEvent.getPlaceId(),
-                placeService.readPlacesV2(routieSpaceIdentifier)
+                placeService.readPlacesV3(routieSpaceIdentifier)
         );
         final SseMessage message = new SseMessage("PLACE_CREATED", placeCreateResponse);
         routieSpaceSseEmitters.broadcast(routieSpaceIdentifier, message);
@@ -68,7 +68,7 @@ public class PlaceEventBroadcaster {
     ) {
         final String routieSpaceIdentifier = routieSpaceSseEstablishedEvent.getRoutieSpaceIdentifier();
         final SsePlaceHistoryResponse placeHistoryResponse = SsePlaceHistoryResponse.from(
-                placeService.readPlacesV2(routieSpaceIdentifier)
+                placeService.readPlacesV3(routieSpaceIdentifier)
         );
         final SseMessage message = new SseMessage("PLACE_HISTORY", placeHistoryResponse);
         message.sendTo(routieSpaceSseEstablishedEvent.getEmitter());

--- a/backend/spring-routie/src/main/java/routie/business/place/ui/dto/event/SsePlaceCreateResponse.java
+++ b/backend/spring-routie/src/main/java/routie/business/place/ui/dto/event/SsePlaceCreateResponse.java
@@ -1,7 +1,7 @@
 package routie.business.place.ui.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import routie.business.place.ui.dto.response.PlaceListResponseV2;
+import routie.business.place.ui.dto.response.PlaceListResponseV3;
 
 import java.util.List;
 
@@ -12,18 +12,19 @@ public record SsePlaceCreateResponse(
 
     public static SsePlaceCreateResponse createWithPlaceListResponseV2(
             final Long updatedPlaceId,
-            final PlaceListResponseV2 placeListResponseV2
+            final PlaceListResponseV3 placeListResponseV3
     ) {
-        final List<SsePlaceResponse> ssePlaceResponses = placeListResponseV2.places().stream()
-                .map(placeCardResponseV2 -> new SsePlaceResponse(
-                        placeCardResponseV2.id(),
-                        placeCardResponseV2.name(),
-                        placeCardResponseV2.roadAddressName(),
-                        placeCardResponseV2.addressName(),
-                        placeCardResponseV2.longitude(),
-                        placeCardResponseV2.latitude(),
-                        placeCardResponseV2.likeCount(),
-                        placeCardResponseV2.hashtags()
+        final List<SsePlaceResponse> ssePlaceResponses = placeListResponseV3.places().stream()
+                .map(placeCardResponseV3 -> new SsePlaceResponse(
+                        placeCardResponseV3.id(),
+                        placeCardResponseV3.name(),
+                        placeCardResponseV3.roadAddressName(),
+                        placeCardResponseV3.addressName(),
+                        placeCardResponseV3.longitude(),
+                        placeCardResponseV3.latitude(),
+                        placeCardResponseV3.likeCount(),
+                        placeCardResponseV3.kakaoPlaceId(),
+                        placeCardResponseV3.hashtags()
                 ))
                 .toList();
 
@@ -38,6 +39,7 @@ public record SsePlaceCreateResponse(
             Double longitude,
             Double latitude,
             Long likeCount,
+            String kakaoPlaceId,
             List<String> hashtags
     ) {
     }

--- a/backend/spring-routie/src/main/java/routie/business/place/ui/dto/event/SsePlaceDeleteResponse.java
+++ b/backend/spring-routie/src/main/java/routie/business/place/ui/dto/event/SsePlaceDeleteResponse.java
@@ -1,7 +1,7 @@
 package routie.business.place.ui.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import routie.business.place.ui.dto.response.PlaceListResponseV2;
+import routie.business.place.ui.dto.response.PlaceListResponseV3;
 
 import java.util.List;
 
@@ -12,18 +12,19 @@ public record SsePlaceDeleteResponse(
 
     public static SsePlaceDeleteResponse createWithPlaceListResponseV2(
             final Long updatedPlaceId,
-            final PlaceListResponseV2 placeListResponseV2
+            final PlaceListResponseV3 placeListResponseV3
     ) {
-        final List<SsePlaceResponse> ssePlaceResponses = placeListResponseV2.places().stream()
-                .map(placeCardResponseV2 -> new SsePlaceResponse(
-                        placeCardResponseV2.id(),
-                        placeCardResponseV2.name(),
-                        placeCardResponseV2.roadAddressName(),
-                        placeCardResponseV2.addressName(),
-                        placeCardResponseV2.longitude(),
-                        placeCardResponseV2.latitude(),
-                        placeCardResponseV2.likeCount(),
-                        placeCardResponseV2.hashtags()
+        final List<SsePlaceResponse> ssePlaceResponses = placeListResponseV3.places().stream()
+                .map(placeCardResponseV3 -> new SsePlaceResponse(
+                        placeCardResponseV3.id(),
+                        placeCardResponseV3.name(),
+                        placeCardResponseV3.roadAddressName(),
+                        placeCardResponseV3.addressName(),
+                        placeCardResponseV3.longitude(),
+                        placeCardResponseV3.latitude(),
+                        placeCardResponseV3.likeCount(),
+                        placeCardResponseV3.kakaoPlaceId(),
+                        placeCardResponseV3.hashtags()
                 ))
                 .toList();
 
@@ -38,6 +39,7 @@ public record SsePlaceDeleteResponse(
             Double longitude,
             Double latitude,
             Long likeCount,
+            String kakaoPlaceId,
             List<String> hashtags
     ) {
     }

--- a/backend/spring-routie/src/main/java/routie/business/place/ui/dto/event/SsePlaceHistoryResponse.java
+++ b/backend/spring-routie/src/main/java/routie/business/place/ui/dto/event/SsePlaceHistoryResponse.java
@@ -1,7 +1,7 @@
 package routie.business.place.ui.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import routie.business.place.ui.dto.response.PlaceListResponseV2;
+import routie.business.place.ui.dto.response.PlaceListResponseV3;
 
 import java.util.List;
 
@@ -9,17 +9,18 @@ public record SsePlaceHistoryResponse(
         @JsonProperty("places") List<SsePlaceResponse> ssePlaceResponses
 ) {
 
-    public static SsePlaceHistoryResponse from(final PlaceListResponseV2 placeListResponseV2) {
-        final List<SsePlaceResponse> ssePlaceResponses = placeListResponseV2.places().stream()
-                .map(placeCardResponseV2 -> new SsePlaceResponse(
-                        placeCardResponseV2.id(),
-                        placeCardResponseV2.name(),
-                        placeCardResponseV2.roadAddressName(),
-                        placeCardResponseV2.addressName(),
-                        placeCardResponseV2.longitude(),
-                        placeCardResponseV2.latitude(),
-                        placeCardResponseV2.likeCount(),
-                        placeCardResponseV2.hashtags()
+    public static SsePlaceHistoryResponse from(final PlaceListResponseV3 placeListResponseV3) {
+        final List<SsePlaceResponse> ssePlaceResponses = placeListResponseV3.places().stream()
+                .map(placeCardResponseV3 -> new SsePlaceResponse(
+                        placeCardResponseV3.id(),
+                        placeCardResponseV3.name(),
+                        placeCardResponseV3.roadAddressName(),
+                        placeCardResponseV3.addressName(),
+                        placeCardResponseV3.longitude(),
+                        placeCardResponseV3.latitude(),
+                        placeCardResponseV3.likeCount(),
+                        placeCardResponseV3.kakaoPlaceId(),
+                        placeCardResponseV3.hashtags()
                 ))
                 .toList();
 
@@ -34,6 +35,7 @@ public record SsePlaceHistoryResponse(
             Double longitude,
             Double latitude,
             Long likeCount,
+            String kakaoPlaceId,
             List<String> hashtags
     ) {
     }

--- a/backend/spring-routie/src/main/java/routie/business/place/ui/dto/event/SsePlaceUpdateResponse.java
+++ b/backend/spring-routie/src/main/java/routie/business/place/ui/dto/event/SsePlaceUpdateResponse.java
@@ -1,7 +1,7 @@
 package routie.business.place.ui.dto.event;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import routie.business.place.ui.dto.response.PlaceListResponseV2;
+import routie.business.place.ui.dto.response.PlaceListResponseV3;
 
 import java.util.List;
 
@@ -12,18 +12,19 @@ public record SsePlaceUpdateResponse(
 
     public static SsePlaceUpdateResponse createWithPlaceListResponseV2(
             final Long updatedPlaceId,
-            final PlaceListResponseV2 placeListResponseV2
+            final PlaceListResponseV3 placeListResponseV3
     ) {
-        final List<SsePlaceResponse> ssePlaceResponses = placeListResponseV2.places().stream()
-                .map(placeCardResponseV2 -> new SsePlaceResponse(
-                        placeCardResponseV2.id(),
-                        placeCardResponseV2.name(),
-                        placeCardResponseV2.roadAddressName(),
-                        placeCardResponseV2.addressName(),
-                        placeCardResponseV2.longitude(),
-                        placeCardResponseV2.latitude(),
-                        placeCardResponseV2.likeCount(),
-                        placeCardResponseV2.hashtags()
+        final List<SsePlaceResponse> ssePlaceResponses = placeListResponseV3.places().stream()
+                .map(placeCardResponseV3 -> new SsePlaceResponse(
+                        placeCardResponseV3.id(),
+                        placeCardResponseV3.name(),
+                        placeCardResponseV3.roadAddressName(),
+                        placeCardResponseV3.addressName(),
+                        placeCardResponseV3.longitude(),
+                        placeCardResponseV3.latitude(),
+                        placeCardResponseV3.likeCount(),
+                        placeCardResponseV3.kakaoPlaceId(),
+                        placeCardResponseV3.hashtags()
                 ))
                 .toList();
 
@@ -38,6 +39,7 @@ public record SsePlaceUpdateResponse(
             Double longitude,
             Double latitude,
             Long likeCount,
+            String kakaoPlaceId,
             List<String> hashtags
     ) {
     }


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
장소 sse 브로드캐스팅에서 v2 응답을 사용중이었음.
장소 카카오 딥링크 적용으로 인해 v3 를 응답해야 함.

## To-Be
<!-- 변경 사항 -->
장소 sse 브로드캐스팅에서 v3 를 응답하도록 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

Closes #990 