### PR TITLE
fix: 루티 스페이스 수정 시 이벤트를 발생시키도록 변경

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
+++ b/backend/spring-routie/src/main/java/routie/business/routiespace/application/RoutieSpaceService.java
@@ -1,8 +1,7 @@
 package routie.business.routiespace.application;
 
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import routie.business.hashtag.domain.HashtagRepository;
@@ -12,6 +11,7 @@ import routie.business.place.domain.PlaceRepository;
 import routie.business.routiespace.domain.RoutieSpace;
 import routie.business.routiespace.domain.RoutieSpaceIdentifierProvider;
 import routie.business.routiespace.domain.RoutieSpaceRepository;
+import routie.business.routiespace.domain.evenet.RoutieSpaceUpdateEvent;
 import routie.business.routiespace.ui.dto.request.RoutieSpaceUpdateRequest;
 import routie.business.routiespace.ui.dto.response.RoutieSpaceCreateResponse;
 import routie.business.routiespace.ui.dto.response.RoutieSpaceListResponse;
@@ -20,11 +20,14 @@ import routie.business.routiespace.ui.dto.response.RoutieSpaceUpdateResponse;
 import routie.global.exception.domain.BusinessException;
 import routie.global.exception.domain.ErrorCode;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RoutieSpaceService {
 
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final RoutieSpaceRepository routieSpaceRepository;
     private final RoutieSpaceIdentifierProvider routieSpaceIdentifierProvider;
     private final PlaceLikeRepository placeLikeRepository;
@@ -86,6 +89,7 @@ public class RoutieSpaceService {
         validateOwner(user, routieSpace);
         routieSpace.updateName(routieSpaceUpdateRequest.name());
 
+        applicationEventPublisher.publishEvent(new RoutieSpaceUpdateEvent(this, routieSpaceIdentifier));
         return new RoutieSpaceUpdateResponse(routieSpace.getName());
     }
 


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
루티 스페이스 이름 수정 시 이벤트가 발생하지 않고 있었음.

## To-Be
<!-- 변경 사항 -->
루티 스페이스 이름 수정 시 이벤트를 발생시키도록 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


Closes #993 