### PR TITLE
refactor: uuid 보관 방식을 sessionStorage로 변경

### DIFF
--- a/frontend/src/domains/auth/components/GuestLoginSection/GuestLoginSection.tsx
+++ b/frontend/src/domains/auth/components/GuestLoginSection/GuestLoginSection.tsx
@@ -6,6 +6,7 @@ import Input from '@/@common/components/Input/Input';
 import Text from '@/@common/components/Text/Text';
 import { useToastContext } from '@/@common/contexts/useToastContext';
 import { useGuestLoginMutation } from '@/domains/auth/queries/useAuthQuery';
+import { getRoutieSpaceUuid } from '@/domains/utils/routieSpaceUuid';
 import theme from '@/styles/theme';
 
 import type { GuestLoginSectionProps } from './GuestLoginSection.types';
@@ -30,7 +31,7 @@ const GuestLoginSection = ({ onClose }: GuestLoginSectionProps) => {
       return;
     }
 
-    const routieSpaceIdentifier = localStorage.getItem('routieSpaceUuid');
+    const routieSpaceIdentifier = getRoutieSpaceUuid();
 
     if (!routieSpaceIdentifier) {
       showToast({

--- a/frontend/src/domains/routie/apis/routie.ts
+++ b/frontend/src/domains/routie/apis/routie.ts
@@ -7,13 +7,15 @@ import type {
   EditRoutieRequestType,
 } from '@/domains/routie/types/api.types';
 import type { RoutieAdapterType } from '@/domains/routie/types/routie.types';
+import {
+  ensureRoutieSpaceUuid,
+  getRoutieSpaceUuid,
+} from '@/domains/utils/routieSpaceUuid';
 
 const getRoutie = async (): Promise<RoutieAdapterType> => {
-  const routieSpaceUuid = localStorage.getItem('routieSpaceUuid');
+  const routieSpaceUuid = getRoutieSpaceUuid();
 
-  if (!routieSpaceUuid) {
-    throw new Error('루티 스페이스 uuid가 없습니다.');
-  }
+  ensureRoutieSpaceUuid(routieSpaceUuid);
 
   const queryParams = new URLSearchParams();
 
@@ -29,11 +31,9 @@ const getRoutie = async (): Promise<RoutieAdapterType> => {
 };
 
 const editRoutieSequence = async ({ routiePlaces }: EditRoutieRequestType) => {
-  const routieSpaceUuid = localStorage.getItem('routieSpaceUuid');
+  const routieSpaceUuid = getRoutieSpaceUuid();
 
-  if (!routieSpaceUuid) {
-    throw new Error('루티 스페이스 uuid가 없습니다.');
-  }
+  ensureRoutieSpaceUuid(routieSpaceUuid);
 
   await apiClient.patch(`/v1/routie-spaces/${routieSpaceUuid}/routie`, {
     routiePlaces,
@@ -43,11 +43,9 @@ const editRoutieSequence = async ({ routiePlaces }: EditRoutieRequestType) => {
 const addRoutiePlace = async ({
   placeId,
 }: AddRoutiePlaceRequestType): Promise<AddRoutiePlaceResponseType> => {
-  const routieSpaceUuid = localStorage.getItem('routieSpaceUuid');
+  const routieSpaceUuid = getRoutieSpaceUuid();
 
-  if (!routieSpaceUuid) {
-    throw new Error('루티 스페이스 uuid가 없습니다.');
-  }
+  ensureRoutieSpaceUuid(routieSpaceUuid);
 
   const response = await apiClient.post(
     `/v1/routie-spaces/${routieSpaceUuid}/routie/places`,
@@ -62,11 +60,9 @@ const addRoutiePlace = async ({
 };
 
 const deleteRoutiePlace = async ({ placeId }: DeleteRoutiePlaceRequestType) => {
-  const routieSpaceUuid = localStorage.getItem('routieSpaceUuid');
+  const routieSpaceUuid = getRoutieSpaceUuid();
 
-  if (!routieSpaceUuid) {
-    throw new Error('루티 스페이스 uuid가 없습니다.');
-  }
+  ensureRoutieSpaceUuid(routieSpaceUuid);
 
   return await apiClient.delete(
     `/v1/routie-spaces/${routieSpaceUuid}/routie/places/${placeId}`,

--- a/frontend/src/domains/routieSpace/apis/routieSpace.ts
+++ b/frontend/src/domains/routieSpace/apis/routieSpace.ts
@@ -16,6 +16,10 @@ import type {
   GetRoutieSpaceListAdapterType,
   RoutieSpaceAdapterType,
 } from '@/domains/routieSpace/types/routieSpace.types';
+import {
+  ensureRoutieSpaceUuid,
+  getRoutieSpaceUuid,
+} from '@/domains/utils/routieSpaceUuid';
 
 const createRoutieSpace = async (): Promise<CreateRoutieSpaceAdapterType> => {
   const accessToken = getAccessTokenOrThrow();
@@ -34,11 +38,9 @@ const createRoutieSpace = async (): Promise<CreateRoutieSpaceAdapterType> => {
 };
 
 const getRoutieSpace = async (): Promise<RoutieSpaceAdapterType> => {
-  const routieSpaceUuid = localStorage.getItem('routieSpaceUuid');
+  const routieSpaceUuid = getRoutieSpaceUuid();
 
-  if (!routieSpaceUuid) {
-    throw new Error('루티 스페이스 uuid가 없습니다.');
-  }
+  ensureRoutieSpaceUuid(routieSpaceUuid);
 
   const response = await apiClient.get(`/v1/routie-spaces/${routieSpaceUuid}`);
 
@@ -50,12 +52,10 @@ const getRoutieSpace = async (): Promise<RoutieSpaceAdapterType> => {
 const editRoutieSpaceName = async ({
   name,
 }: EditRoutieSpaceNameRequestType): Promise<EditRoutieSpaceNameAdapterType> => {
-  const routieSpaceUuid = localStorage.getItem('routieSpaceUuid');
+  const routieSpaceUuid = getRoutieSpaceUuid();
   const accessToken = getAccessTokenOrThrow();
 
-  if (!routieSpaceUuid) {
-    throw new Error('루티 스페이스 uuid가 없습니다.');
-  }
+  ensureRoutieSpaceUuid(routieSpaceUuid);
 
   const response = await apiClient.patch(
     `/v2/routie-spaces/${routieSpaceUuid}`,

--- a/frontend/src/domains/routieSpace/hooks/useShareLink.ts
+++ b/frontend/src/domains/routieSpace/hooks/useShareLink.ts
@@ -2,13 +2,13 @@ import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { useToastContext } from '@/@common/contexts/useToastContext';
+import { getRoutieSpaceUuid } from '@/domains/utils/routieSpaceUuid';
 
 const useShareLink = () => {
   const [searchParams] = useSearchParams();
   const { showToast } = useToastContext();
   const routieSpaceIdentifier =
-    searchParams.get('routieSpaceIdentifier') ??
-    localStorage.getItem('routieSpaceUuid');
+    searchParams.get('routieSpaceIdentifier') ?? getRoutieSpaceUuid();
 
   const shareLink = useMemo(() => {
     if (!routieSpaceIdentifier) return '';

--- a/frontend/src/domains/utils/routieSpaceUuid.ts
+++ b/frontend/src/domains/utils/routieSpaceUuid.ts
@@ -1,6 +1,8 @@
+import { sessionStorageUtils } from '@/@common/utils/sessionStorage';
+
 const getRoutieSpaceUuid = (): string | null => {
   return typeof window !== 'undefined'
-    ? localStorage.getItem('routieSpaceUuid')
+    ? sessionStorageUtils.get('routieSpaceUuid', null)
     : null;
 };
 

--- a/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
+++ b/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
@@ -37,7 +37,7 @@ const RoutieSpace = () => {
 
   useLayoutEffect(() => {
     if (routieSpaceIdentifier) {
-      localStorage.setItem('routieSpaceUuid', routieSpaceIdentifier);
+      sessionStorageUtils.set('routieSpaceUuid', routieSpaceIdentifier);
     }
   }, [routieSpaceIdentifier]);
 

--- a/frontend/src/pages/RoutieSpaceNotFound/RoutieSpaceNotFound.tsx
+++ b/frontend/src/pages/RoutieSpaceNotFound/RoutieSpaceNotFound.tsx
@@ -5,6 +5,7 @@ import Button from '@/@common/components/Button/Button';
 import Flex from '@/@common/components/Flex/Flex';
 import Text from '@/@common/components/Text/Text';
 import { useModal } from '@/@common/contexts/ModalContext';
+import { sessionStorageUtils } from '@/@common/utils/sessionStorage';
 import theme from '@/styles/theme';
 
 import { ErrorPageContainerStyle } from './RoutieSpaceNotFound.styles';
@@ -14,7 +15,7 @@ const RoutieSpaceNotFound = () => {
   const { closeModal } = useModal();
 
   useEffect(() => {
-    localStorage.removeItem('routieSpaceUuid');
+    sessionStorageUtils.remove('routieSpaceUuid');
     closeModal();
   }, []);
 


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- uuid가 로컬 스토리지에 저장되고 있어서 탭간 uuid가 공유되는 문제가 발생

## To-Be
<!-- 변경 사항 -->
- uuid를 세션 스토리지 방식으로 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


Closes #1006 
