### PR TITLE
fix: 지도 위 해시태그 버튼 버그 수정

### DIFF
--- a/frontend/src/domains/places/hooks/usePlaceStream.ts
+++ b/frontend/src/domains/places/hooks/usePlaceStream.ts
@@ -83,6 +83,7 @@ const usePlaceStream = () => {
         type: 'success',
       });
       replacePlaceList({ places });
+      queryClient.invalidateQueries({ queryKey: placesKeys.hashtags() });
     },
   });
 };


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
장소에서 해시태그를 수정했을 때, 지도 위의 해시태그 목록에 반영되지 않고 새로고침 시에만 반영되었던 문제 해결

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

Closes #1011
