### PR TITLE
feat: 공유 링크에 루티스페이스 이름 Query Parameter 추가

### DIFF
--- a/frontend/src/domains/routieSpace/hooks/useShareLink.ts
+++ b/frontend/src/domains/routieSpace/hooks/useShareLink.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { useToastContext } from '@/@common/contexts/useToastContext';
+import { useRoutieSpaceQuery } from '@/domains/routieSpace/queries/useRoutieSpaceQuery';
 import { getRoutieSpaceUuid } from '@/domains/utils/routieSpaceUuid';
 
 const useShareLink = () => {
@@ -9,11 +10,21 @@ const useShareLink = () => {
   const { showToast } = useToastContext();
   const routieSpaceIdentifier =
     searchParams.get('routieSpaceIdentifier') ?? getRoutieSpaceUuid();
+  const { data: routieSpace } = useRoutieSpaceQuery({ enabled: false });
 
   const shareLink = useMemo(() => {
     if (!routieSpaceIdentifier) return '';
-    return `${window.location.origin}/routie-spaces?routieSpaceIdentifier=${routieSpaceIdentifier}`;
-  }, [routieSpaceIdentifier]);
+
+    const params = new URLSearchParams({
+      routieSpaceIdentifier,
+    });
+
+    if (routieSpace?.name) {
+      params.set('name', routieSpace.name);
+    }
+
+    return `${window.location.origin}/routie-spaces?${params.toString()}`;
+  }, [routieSpaceIdentifier, routieSpace?.name]);
 
   const handleCopyLink = useCallback(async () => {
     try {


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->
기존에는 routieSpaceIdentifier만 추출하였는데, 루티스페이스 이름 Query Parameter도 함께 추가하였습니다!

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description

Closes #1031 