### PR TITLE
fix: 루티 수정 시 데드락 문제 해결

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/routie/application/RoutieService.java
+++ b/backend/spring-routie/src/main/java/routie/business/routie/application/RoutieService.java
@@ -131,7 +131,7 @@ public class RoutieService {
         final List<RoutiePlace> routiePlaces = routie.getRoutiePlaces();
 
         final Map<Long, RoutiePlace> existingRoutiePlacesByPlaceId = routiePlaces.stream()
-                .collect(Collectors.toMap(rp -> rp.getPlace().getId(), Function.identity()));
+                .collect(Collectors.toMap(routiePlace -> routiePlace.getPlace().getId(), Function.identity()));
 
         final Set<Long> requestedPlaceIds = routieUpdateRequest.routiePlaces().stream()
                 .map(RoutiePlaceRequest::placeId)


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- Routie 수정시 대량 DELETE 후 INSERT가 한 트랜잭션에서 실행되어, 락 경합과 데드락이 빈번하게 발생함
- 단방향 `@OneToMany + orphanRemoval + Embeddable` 구조에서 리스트 remove만으로 DB 삭제가 트리거되지 않아 데이터 부정합 가능성 존재

## To-Be
<!-- 변경 사항 -->
- 대량 DELETE 대신, 요청에 없는 장소만 개별적으로 직접 Repository를 통해 deleteAllById로 삭제함
- 이미 존재하는 장소는 sequence만 UPDATE, 신규 장소만 INSERT하여, UPDATE/INSERT/DELETE를 분리 처리
- 불필요한 락 범위 최소화 및 명시적 삭제로 데이터 일관성 확보

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
**문제 상황**
- Routie 수정 API에서 전체 삭제 후 전체 삽입 로직을 사용했을 때, MySQL InnoDB의 외래키 인덱스에 광범위한 Next-Key Lock/GAP Lock이 발생했고, 동시 수정 요청 시 교차 락 경합에 의해 DELETE에서 걸린 락에 다른 트랙젝션에서 INSERT 시 데드락이 자주 재현됨.
- 단방향 `@OneToMany`와 `Embeddable` 구조에서는 컬렉션에서 remove만 할 경우 orphanRemoval이 제대로 동작하지 않아 실제 DB 삭제가 이루어지지 않는 문제 또한 발견.

**해결방법 비교**
- 데드락 증상 개선을 위해 INSERT 정렬, 트랜잭션 격리 수준 하향, 재시도 로직, 비관적 락 등 여러 해결책을 검토
- 가장 효과적이고 근본적인 방법은 “대량 DELETE를 피하고, 필요한 항목만 UPDATE/INSERT/DELETE로 직접 처리하는” 방식임을 확인
- Repository의 명시적인 delete를 통해 엔티티–DB 간 삭제 상태를 확실히 동기화, 데이터 부정합까지 함께 방지

**선택 및 근거**
- 불필요한 인덱스 락 범위를 최소화하여 교차 데드락 발생 구조를 근본적으로 방지할 수 있음
- 공동 작업이 주요 기능이기에 트랜잭션 격리 수준을 하향시키는 것은 Phantom Read 현상이 나타날 가능성이 높아 배제
- INSERT 정렬, 재시도 로직, 비관적 락 등의 방법은 데드락을 근본적으로 해결하지 못함

### 기존
<img width="990" height="248" alt="original 3" src="https://github.com/user-attachments/assets/6014016c-4a88-4f3b-b4c8-89a52a4bb455" />

### 변경 후
<img width="988" height="255" alt="deleteById3" src="https://github.com/user-attachments/assets/562bd688-9568-4679-98b6-e6f112db8e24" />

- 데드락 문제 해결
- 평균 응답 시간 80ms -> 56ms으로 30% 단축

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
closes #1039 