### PR TITLE
docs: places 도메인 폴더 내부에 agents.md, claude.md 파일 작성

### DIFF
--- a/frontend/src/domains/places/AGENTS.md
+++ b/frontend/src/domains/places/AGENTS.md
@@ -14,7 +14,7 @@
 - `adapters/`: 서버 응답 → UI 모델 변환 (`placeAdapter.ts`)
 - `apis/`: 도메인 API 호출 (`place.ts`)
 - `components/`: 도메인 공용 컴포넌트 (스토리 포함)
-- `contexts/`: 도메인 컨텍스트
+- `contexts/`: 도메인 내 여러 곳에서 공유되는 전역 상태 관리
 - `hooks/`: 도메인 훅
 - `queries/`: React Query hooks (`key.ts`에서 query key 관리)
 - `types/`: 도메인 타입

--- a/frontend/src/domains/places/AGENTS.md
+++ b/frontend/src/domains/places/AGENTS.md
@@ -21,6 +21,7 @@
 - `utils/`: 도메인 유틸
 
 ## API/Adapter 규칙 (places 한정)
+- 서버 응답이 추가될 때는 adapter를 반드시 추가
 - 해시태그 요청 전 `removeHashtagPrefix`로 포맷 정리
 - 해시태그 응답은 `addHashtagPrefix`로 표시 포맷 유지
 

--- a/frontend/src/domains/places/AGENTS.md
+++ b/frontend/src/domains/places/AGENTS.md
@@ -20,22 +20,8 @@
 - `types/`: 도메인 타입
 - `utils/`: 도메인 유틸
 
-## 타입 규칙 (places 한정)
-- API 타입: `types/api.types.ts` (Request/Response 분리)
-- 클라이언트 타입: `types/places.types.ts`
-- 객체는 interface, 나머지는 type
-- export/import는 `export type` / `import type` 사용
-
-## API 규칙
-- 공통 `apiClient` 사용
-- 에러 처리: `handleApiError` 필수
-- 인증 필요 시 `getAccessTokenOrThrow`
-- Routie Space 필요 시 `getRoutieSpaceUuid` / `ensureRoutieSpaceUuid`
+## API/Adapter 규칙 (places 한정)
 - 해시태그 요청 전 `removeHashtagPrefix`로 포맷 정리
-
-## Adapter 규칙
-- 서버 모델 → UI 모델 변환은 반드시 adapter로 분리
-- adapter 함수명: `convertXxxResponseToXxx`
 - 해시태그 응답은 `addHashtagPrefix`로 표시 포맷 유지
 
 ## React Query 규칙
@@ -44,12 +30,6 @@
 - 데이터 변환은 `select` 또는 adapter 사용
 - mutation 성공 시 관련 query invalidate
 - 장소 삭제 시 GA 이벤트 트리거가 필요하면 `usePlaceQuery.ts` 패턴 유지
-
-## 네이밍 규칙 (places 한정)
-- boolean: `is/has/can`
-- handler: `handleXxx`
-- props: `XxxProps`
-- params: `XxxParams`
 
 ## 도메인 정책 (places 한정)
 - 해시태그 입력: 최대 5개, 최대 7자 제한

--- a/frontend/src/domains/places/AGENTS.md
+++ b/frontend/src/domains/places/AGENTS.md
@@ -1,0 +1,63 @@
+# AGENTS.md (domains/places)
+
+## 목적
+- places 도메인 변경 시 안전하고 일관된 적용을 위한 규칙
+
+## 전역 규칙
+- 프로젝트 전역 규칙은 전역 `AGENTS.md`를 따른다
+- 이 문서는 places 도메인 특화 규칙만 정의한다
+
+## 도메인 개요
+- 책임: 장소 검색/목록·상세 조회/추가·삭제/좋아요/해시태그 관리 및 필터링/실시간 동기화(SSE)
+
+## 폴더/파일 구조
+- `adapters/`: 서버 응답 → UI 모델 변환 (`placeAdapter.ts`)
+- `apis/`: 도메인 API 호출 (`place.ts`)
+- `components/`: 도메인 공용 컴포넌트 (스토리 포함)
+- `contexts/`: 도메인 컨텍스트
+- `hooks/`: 도메인 훅
+- `queries/`: React Query hooks (`key.ts`에서 query key 관리)
+- `types/`: 도메인 타입
+- `utils/`: 도메인 유틸
+
+## 타입 규칙 (places 한정)
+- API 타입: `types/api.types.ts` (Request/Response 분리)
+- 클라이언트 타입: `types/places.types.ts`
+- 객체는 interface, 나머지는 type
+- export/import는 `export type` / `import type` 사용
+
+## API 규칙
+- 공통 `apiClient` 사용
+- 에러 처리: `handleApiError` 필수
+- 인증 필요 시 `getAccessTokenOrThrow`
+- Routie Space 필요 시 `getRoutieSpaceUuid` / `ensureRoutieSpaceUuid`
+- 해시태그 요청 전 `removeHashtagPrefix`로 포맷 정리
+
+## Adapter 규칙
+- 서버 모델 → UI 모델 변환은 반드시 adapter로 분리
+- adapter 함수명: `convertXxxResponseToXxx`
+- 해시태그 응답은 `addHashtagPrefix`로 표시 포맷 유지
+
+## React Query 규칙
+- query key 네이밍: `['places', ...]`
+- query key는 `queries/key.ts`에서 정의
+- 데이터 변환은 `select` 또는 adapter 사용
+- mutation 성공 시 관련 query invalidate
+- 장소 삭제 시 GA 이벤트 트리거가 필요하면 `usePlaceQuery.ts` 패턴 유지
+
+## 네이밍 규칙 (places 한정)
+- boolean: `is/has/can`
+- handler: `handleXxx`
+- props: `XxxProps`
+- params: `XxxParams`
+
+## 도메인 정책 (places 한정)
+- 해시태그 입력: 최대 5개, 최대 7자 제한
+- 해시태그 필터 상태는 `sessionStorage`의 `selectedHashtags` 키로 유지
+- 좋아요는 인증 필요하며, 토큰이 없으면 요청을 중단
+- SSE 이벤트(PLACE_HISTORY/CREATED/UPDATED/DELETED)로 장소 목록 동기화
+- 데이터 SSOT는 SSE이며, 초기 데이터 fetch는 기본적으로 비활성화하고 SSE 결과만 사용
+
+## 변경 시 체크리스트
+- 타입 먼저 추가 → API 연결 → adapter → hook → UI
+- 불필요한 포맷팅 변경 금지

--- a/frontend/src/domains/places/CLAUDE.md
+++ b/frontend/src/domains/places/CLAUDE.md
@@ -1,0 +1,44 @@
+# AGENTS.md (domains/places)
+
+## 목적
+- places 도메인 변경 시 안전하고 일관된 적용을 위한 규칙
+
+## 전역 규칙
+- 프로젝트 전역 규칙은 전역 `AGENTS.md`를 따른다
+- 이 문서는 places 도메인 특화 규칙만 정의한다
+
+## 도메인 개요
+- 책임: 장소 검색/목록·상세 조회/추가·삭제/좋아요/해시태그 관리 및 필터링/실시간 동기화(SSE)
+
+## 폴더/파일 구조
+- `adapters/`: 서버 응답 → UI 모델 변환 (`placeAdapter.ts`)
+- `apis/`: 도메인 API 호출 (`place.ts`)
+- `components/`: 도메인 공용 컴포넌트 (스토리 포함)
+- `contexts/`: 도메인 내 여러 곳에서 공유되는 전역 상태 관리
+- `hooks/`: 도메인 훅
+- `queries/`: React Query hooks (`key.ts`에서 query key 관리)
+- `types/`: 도메인 타입
+- `utils/`: 도메인 유틸
+
+## API/Adapter 규칙 (places 한정)
+- 서버 응답이 추가될 때는 adapter를 반드시 추가
+- 해시태그 요청 전 `removeHashtagPrefix`로 포맷 정리
+- 해시태그 응답은 `addHashtagPrefix`로 표시 포맷 유지
+
+## React Query 규칙
+- query key 네이밍: `['places', ...]`
+- query key는 `queries/key.ts`에서 정의
+- 데이터 변환은 `select` 또는 adapter 사용
+- mutation 성공 시 관련 query invalidate
+- 장소 삭제 시 GA 이벤트 트리거가 필요하면 `usePlaceQuery.ts` 패턴 유지
+
+## 도메인 정책 (places 한정)
+- 해시태그 입력: 최대 5개, 최대 7자 제한
+- 해시태그 필터 상태는 `sessionStorage`의 `selectedHashtags` 키로 유지
+- 좋아요는 인증 필요하며, 토큰이 없으면 요청을 중단
+- SSE 이벤트(PLACE_HISTORY/CREATED/UPDATED/DELETED)로 장소 목록 동기화
+- 데이터 SSOT는 SSE이며, 초기 데이터 fetch는 기본적으로 비활성화하고 SSE 결과만 사용
+
+## 변경 시 체크리스트
+- 타입 먼저 추가 → API 연결 → adapter → hook → UI
+- 불필요한 포맷팅 변경 금지


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- places 도메인의 변경 규칙과 정책이 코드와 개인 기억에 의존
- SSE 기반 동기화, adapter 사용, 해시태그 포맷 규칙 등이 명시적으로 문서화되어 있지 않음
- 신규 또는 오랜만에 places 도메인을 수정할 경우 실수 가능성이 존재

## To-Be
<!-- 변경 사항 -->
- places 도메인 전용 `AGENTS.md`를 추가해 도메인 특화 규칙을 문서로 고정
- adapter / React Query / SSE(SSOT) 사용 규칙 명확화
- 해시태그, 좋아요, 필터링 등 places 도메인 정책 명시
- 변경 시 표준 작업 순서와 체크리스트 제공

폴더 구조 명시하고 코드나 기능이 추가될 때 참고해야할 API/Adapter 규칙, React Query 규칙, 도메인 정책 을 명시를 해봤습니다. 내용이 조금 짧은데 디테일한 규칙은 전역에 작성되어있는 AGENTS.md를 따르게 하게 해서 중복적인 내용은 작성하지 않았습니다.
더 추가할 내용 있으면 코멘트 달아주세요 👍

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
Closes #1062 
