### PR TITLE
feat: Marker 컴포넌트 및 훅 리액트화

### DIFF
--- a/frontend/src/domains/maps/components/KakaoMap/KakaoMap.tsx
+++ b/frontend/src/domains/maps/components/KakaoMap/KakaoMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import Flex from '@/@common/components/Flex/Flex';
@@ -6,11 +6,20 @@ import Text from '@/@common/components/Text/Text';
 import HashtagFilter from '@/domains/maps/components/HashtagFilter/HashtagFilter';
 import KakaoMapLoadBoundary from '@/domains/maps/components/KakaoMapLoadBoundary/KakaoMapLoadBoundary';
 import Map from '@/domains/maps/components/Map/Map';
+import Marker from '@/domains/maps/components/Marker/Marker';
+import NumberMarker from '@/domains/maps/components/Marker/NumberMarker';
 import PlaceOverlayCard from '@/domains/maps/components/PlaceOverlayCard/PlaceOverlayCard';
 import { useClickedPlace } from '@/domains/maps/hooks/useClickedPlace';
 import { useCustomOverlay } from '@/domains/maps/hooks/useCustomOverlay';
 import { useMap } from '@/domains/maps/hooks/useMap';
+import { useMapNavigation } from '@/domains/maps/hooks/useMapNavigation';
 import { useMapRenderer } from '@/domains/maps/hooks/useMapRenderer';
+import { useRoutePlacesWithDetails } from '@/domains/maps/hooks/useRoutePlacesWithDetails';
+import { useHashtagFilterContext } from '@/domains/places/contexts/useHashtagFilterContext';
+import { usePlaceList } from '@/domains/places/hooks/usePlaceList';
+import type { PlaceDataType } from '@/domains/places/types/place.types';
+import { filterPlacesByHashtags } from '@/domains/places/utils/filterPlaces';
+
 
 
 import {
@@ -57,7 +66,7 @@ const MapError = ({ error }: { error: Error }) => (
  *
  * @description
  * Map 컴포넌트 내부에서 렌더링되며 useMap()을 통해 지도 인스턴스에 접근합니다.
- * 기존 훅들과의 호환성을 위해 mapRef 패턴을 유지합니다.
+ * 마커는 Marker/NumberMarker 컴포넌트로 선언적 렌더링합니다.
  *
  * @param props - 컴포넌트 Props
  * @param props.isSidebarOpen - 사이드바 열림 상태
@@ -70,17 +79,54 @@ const MapContent = ({ isSidebarOpen }: { isSidebarOpen: boolean }) => {
   const mapRef = useRef<KakaoMapType | null>(null);
   mapRef.current = map;
 
+  // 장소 데이터
+  const { placeList } = usePlaceList();
+  const { routiePlacesWithDetails } = useRoutePlacesWithDetails();
+  const { selectedHashtags } = useHashtagFilterContext();
+
   const { containerEl, openAt, close } = useCustomOverlay(mapRef);
   const { clickedPlace, handleMapClick, handleMarkerClick } = useClickedPlace({
     openAt,
     close,
   });
+
+  // 마커 클릭 시 지도 이동을 위한 navigateToPlace
+  const { navigateToPlace } = useMapNavigation({
+    mapRef,
+    isInitialLoad,
+    setIsInitialLoad,
+  });
+
   const { renderMapElements } = useMapRenderer({
     mapRef,
     isInitialLoad,
     setIsInitialLoad,
-    handleMarkerClick,
   });
+
+  // 마커 클릭 핸들러 (오버레이 표시 + 지도 이동)
+  const handleMarkerClickWithNavigation = useCallback(
+    (place: PlaceDataType) => {
+      handleMarkerClick(place);
+      navigateToPlace(place);
+    },
+    [handleMarkerClick, navigateToPlace],
+  );
+
+  // 필터링된 장소 목록 (기본 마커용 - routieSequence 없는 것만)
+  const basicMarkerPlaces = useMemo(() => {
+    if (!placeList) return [];
+
+    const routiePlaceIds = new Set(routiePlacesWithDetails.map((rp) => rp.id));
+
+    const filteredPlaces = filterPlacesByHashtags({
+      places: placeList,
+      selectedHashtags,
+      priorityPlaceIds: [...routiePlaceIds],
+    });
+
+    // routieSequence가 없는 장소만 (기본 마커)
+    return filteredPlaces.filter((place) => !routiePlaceIds.has(place.id));
+  }, [placeList, routiePlacesWithDetails, selectedHashtags]);
 
   // 지도 클릭 이벤트 등록
   useEffect(() => {
@@ -93,7 +139,7 @@ const MapContent = ({ isSidebarOpen }: { isSidebarOpen: boolean }) => {
     };
   }, [map, handleMapClick]);
 
-  // 맵 요소 렌더링 (마커, 폴리라인 등)
+  // 맵 요소 렌더링 (폴리라인, 맵 피팅 등 - 마커는 선언적 컴포넌트로 처리)
   useEffect(() => {
     if (!map) return;
     renderMapElements();
@@ -113,6 +159,27 @@ const MapContent = ({ isSidebarOpen }: { isSidebarOpen: boolean }) => {
   return (
     <>
       <HashtagFilter isSidebarOpen={isSidebarOpen} />
+
+      {/* 기본 마커 - 선언적 Marker 컴포넌트 */}
+      {basicMarkerPlaces.map((place) => (
+        <Marker
+          key={place.id}
+          position={{ lat: place.latitude, lng: place.longitude }}
+          title={place.name}
+          onClick={() => handleMarkerClickWithNavigation(place)}
+        />
+      ))}
+
+      {/* 숫자 마커 - 선언적 NumberMarker 컴포넌트 */}
+      {routiePlacesWithDetails.map((place) => (
+        <NumberMarker
+          key={`number-${place.id}`}
+          position={{ lat: place.latitude, lng: place.longitude }}
+          sequence={place.sequence}
+          onClick={() => handleMarkerClickWithNavigation(place)}
+        />
+      ))}
+
       {containerEl &&
         clickedPlace &&
         createPortal(

--- a/frontend/src/domains/maps/components/KakaoMap/KakaoMap.tsx
+++ b/frontend/src/domains/maps/components/KakaoMap/KakaoMap.tsx
@@ -35,6 +35,22 @@ import type { KakaoMap as KakaoMapType } from '../../../../../kakao.d';
 const INITIAL_CENTER = { lat: 37.554, lng: 126.97 };
 const INITIAL_LEVEL = 7;
 
+// 🔬 리렌더링 측정용 (테스트 후 삭제)
+let mapContentRenderCount = 0;
+
+// 🔬 스트레스 테스트용 더미 마커 (테스트 후 삭제)
+const DUMMY_PLACES: PlaceDataType[] = Array.from({ length: 50 }, (_, i) => ({
+  id: 10000 + i,
+  kakaoPlaceId: `dummy-${i}`,
+  name: `더미 장소 ${i + 1}`,
+  latitude: 35.5 + (i % 10) * 0.3,
+  longitude: 127.0 + Math.floor(i / 10) * 0.5,
+  roadAddressName: null,
+  addressName: `더미 주소 ${i + 1}`,
+  hashtags: [],
+  likeCount: 0,
+}));
+
 /**
  * 지도 로딩 중 표시되는 컴포넌트
  */
@@ -72,6 +88,10 @@ const MapError = ({ error }: { error: Error }) => (
  * @param props.isSidebarOpen - 사이드바 열림 상태
  */
 const MapContent = ({ isSidebarOpen }: { isSidebarOpen: boolean }) => {
+  // 🔬 리렌더링 측정용 (테스트 후 삭제)
+  mapContentRenderCount += 1;
+  console.log(`[MapContent] render count: ${mapContentRenderCount}`);
+
   const map = useMap();
   const [isInitialLoad, setIsInitialLoad] = useState(true);
 
@@ -177,6 +197,15 @@ const MapContent = ({ isSidebarOpen }: { isSidebarOpen: boolean }) => {
           position={{ lat: place.latitude, lng: place.longitude }}
           sequence={place.sequence}
           onClick={() => handleMarkerClickWithNavigation(place)}
+        />
+      ))}
+
+      {/* 🔬 스트레스 테스트용 더미 마커 (테스트 후 삭제) */}
+      {DUMMY_PLACES.map((place) => (
+        <Marker
+          key={`dummy-${place.id}`}
+          position={{ lat: place.latitude, lng: place.longitude }}
+          title={place.name}
         />
       ))}
 

--- a/frontend/src/domains/maps/components/Marker/Marker.tsx
+++ b/frontend/src/domains/maps/components/Marker/Marker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { memo, useEffect, useLayoutEffect, useRef } from 'react';
 
 import { useMap } from '@/domains/maps/hooks/useMap';
 import { kakaoMapAdapter } from '@/libs/map-sdk';
@@ -13,6 +13,7 @@ import type { MarkerProps } from './Marker.types';
  * 카카오 지도에 마커를 선언적으로 렌더링하는 컴포넌트입니다.
  * Map 컴포넌트의 자식으로 사용해야 합니다.
  * 컴포넌트가 언마운트되면 마커가 자동으로 제거됩니다.
+ * memo로 감싸서 position/title이 변경될 때만 리렌더링됩니다.
  *
  * @param props - 컴포넌트 Props
  * @param props.position - 마커 위치 { lat, lng }
@@ -30,7 +31,7 @@ import type { MarkerProps } from './Marker.types';
  * </Map>
  * ```
  */
-const Marker = ({ position, title, onClick }: MarkerProps) => {
+const Marker = memo(({ position, title, onClick }: MarkerProps) => {
   const map = useMap();
   const markerRef = useRef<MarkerInstanceType | null>(null);
   const onClickRef = useRef(onClick);
@@ -85,6 +86,16 @@ const Marker = ({ position, title, onClick }: MarkerProps) => {
 
   // UI를 렌더링하지 않음
   return null;
-};
+}, (prevProps, nextProps) => {
+  // true 반환 = 리렌더링 스킵
+  // onClick은 내부에서 ref로 처리하므로 비교하지 않음
+  return (
+    prevProps.position.lat === nextProps.position.lat &&
+    prevProps.position.lng === nextProps.position.lng &&
+    prevProps.title === nextProps.title
+  );
+});
+
+Marker.displayName = 'Marker';
 
 export default Marker;

--- a/frontend/src/domains/maps/components/Marker/Marker.tsx
+++ b/frontend/src/domains/maps/components/Marker/Marker.tsx
@@ -6,6 +6,9 @@ import type { MarkerInstanceType } from '@/libs/map-sdk';
 
 import type { MarkerProps } from './Marker.types';
 
+// 🔬 리렌더링 측정용 (테스트 후 삭제)
+let markerRenderCount = 0;
+
 /**
  * 선언적 마커 컴포넌트
  *
@@ -32,6 +35,10 @@ import type { MarkerProps } from './Marker.types';
  * ```
  */
 const Marker = memo(({ position, title, onClick }: MarkerProps) => {
+  // 🔬 리렌더링 측정용 (테스트 후 삭제)
+  markerRenderCount += 1;
+  console.log(`[Marker "${title}"] render count: ${markerRenderCount}`);
+
   const map = useMap();
   const markerRef = useRef<MarkerInstanceType | null>(null);
   const onClickRef = useRef(onClick);

--- a/frontend/src/domains/maps/components/Marker/Marker.tsx
+++ b/frontend/src/domains/maps/components/Marker/Marker.tsx
@@ -18,10 +18,6 @@ import type { MarkerProps } from './Marker.types';
  * @param props.position - 마커 위치 { lat, lng }
  * @param props.title - 마커 제목 (툴팁)
  * @param props.onClick - 클릭 이벤트 핸들러
- * @param props.clickable - 클릭 가능 여부 @default true
- * @param props.draggable - 드래그 가능 여부 @default false
- * @param props.opacity - 투명도 (0~1)
- * @param props.zIndex - z-index
  *
  * @example
  * ```tsx
@@ -34,15 +30,7 @@ import type { MarkerProps } from './Marker.types';
  * </Map>
  * ```
  */
-const Marker = ({
-  position,
-  title,
-  onClick,
-  clickable = true,
-  draggable = false,
-  opacity,
-  zIndex,
-}: MarkerProps) => {
+const Marker = ({ position, title, onClick }: MarkerProps) => {
   const map = useMap();
   const markerRef = useRef<MarkerInstanceType | null>(null);
   const onClickRef = useRef(onClick);
@@ -57,10 +45,6 @@ const Marker = ({
     const marker = kakaoMapAdapter.createMarker(map, {
       position,
       title,
-      clickable,
-      draggable,
-      opacity,
-      zIndex,
     });
 
     markerRef.current = marker;

--- a/frontend/src/domains/maps/components/Marker/Marker.tsx
+++ b/frontend/src/domains/maps/components/Marker/Marker.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useLayoutEffect, useRef } from 'react';
+
+import { useMap } from '@/domains/maps/hooks/useMap';
+import { kakaoMapAdapter } from '@/libs/map-sdk';
+import type { MarkerInstanceType } from '@/libs/map-sdk';
+
+import type { MarkerProps } from './Marker.types';
+
+/**
+ * 선언적 마커 컴포넌트
+ *
+ * @description
+ * 카카오 지도에 마커를 선언적으로 렌더링하는 컴포넌트입니다.
+ * Map 컴포넌트의 자식으로 사용해야 합니다.
+ * 컴포넌트가 언마운트되면 마커가 자동으로 제거됩니다.
+ *
+ * @param props - 컴포넌트 Props
+ * @param props.position - 마커 위치 { lat, lng }
+ * @param props.title - 마커 제목 (툴팁)
+ * @param props.onClick - 클릭 이벤트 핸들러
+ * @param props.clickable - 클릭 가능 여부 @default true
+ * @param props.draggable - 드래그 가능 여부 @default false
+ * @param props.opacity - 투명도 (0~1)
+ * @param props.zIndex - z-index
+ *
+ * @example
+ * ```tsx
+ * <Map center={{ lat: 37.5, lng: 127.0 }}>
+ *   <Marker
+ *     position={{ lat: 37.5, lng: 127.0 }}
+ *     title="서울"
+ *     onClick={() => console.log('clicked')}
+ *   />
+ * </Map>
+ * ```
+ */
+const Marker = ({
+  position,
+  title,
+  onClick,
+  clickable = true,
+  draggable = false,
+  opacity,
+  zIndex,
+}: MarkerProps) => {
+  const map = useMap();
+  const markerRef = useRef<MarkerInstanceType | null>(null);
+  const onClickRef = useRef(onClick);
+
+  // onClick ref 업데이트 (핸들러 변경 시 리스너 재등록 방지)
+  onClickRef.current = onClick;
+
+  // 마커 생성 (최초 1회)
+  useLayoutEffect(() => {
+    if (!map) return;
+
+    const marker = kakaoMapAdapter.createMarker(map, {
+      position,
+      title,
+      clickable,
+      draggable,
+      opacity,
+      zIndex,
+    });
+
+    markerRef.current = marker;
+
+    // cleanup: 마커 제거
+    return () => {
+      kakaoMapAdapter.removeMarker(marker);
+      markerRef.current = null;
+    };
+    // 의존성: map만 (position 변경은 별도 effect에서 처리)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map]);
+
+  // position 변경 감지 → 위치 업데이트
+  useEffect(() => {
+    if (!markerRef.current) return;
+
+    kakaoMapAdapter.setMarkerPosition(markerRef.current, position);
+    // position 객체 참조가 아닌 실제 좌표 값이 변경될 때만 실행
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [position.lat, position.lng]);
+
+  // click 이벤트 리스너
+  useEffect(() => {
+    const marker = markerRef.current;
+    if (!marker) return;
+
+    const handleClick = () => {
+      onClickRef.current?.();
+    };
+
+    kakaoMapAdapter.addMarkerListener(marker, 'click', handleClick);
+
+    return () => {
+      kakaoMapAdapter.removeMarkerListener(marker, 'click', handleClick);
+    };
+  }, [map]); // map이 변경되면 마커가 재생성되므로 리스너도 재등록
+
+  // UI를 렌더링하지 않음
+  return null;
+};
+
+export default Marker;

--- a/frontend/src/domains/maps/components/Marker/Marker.types.ts
+++ b/frontend/src/domains/maps/components/Marker/Marker.types.ts
@@ -10,14 +10,6 @@ interface MarkerProps {
   title?: string;
   /** 클릭 이벤트 핸들러 */
   onClick?: () => void;
-  /** 클릭 가능 여부 @default true */
-  clickable?: boolean;
-  /** 드래그 가능 여부 @default false */
-  draggable?: boolean;
-  /** 투명도 (0~1) */
-  opacity?: number;
-  /** z-index */
-  zIndex?: number;
 }
 
 export type { MarkerProps };

--- a/frontend/src/domains/maps/components/Marker/Marker.types.ts
+++ b/frontend/src/domains/maps/components/Marker/Marker.types.ts
@@ -1,0 +1,23 @@
+import type { LatLngLiteral } from '@/libs/map-sdk';
+
+/**
+ * Marker 컴포넌트 Props
+ */
+interface MarkerProps {
+  /** 마커 위치 */
+  position: LatLngLiteral;
+  /** 마커 제목 (툴팁) */
+  title?: string;
+  /** 클릭 이벤트 핸들러 */
+  onClick?: () => void;
+  /** 클릭 가능 여부 @default true */
+  clickable?: boolean;
+  /** 드래그 가능 여부 @default false */
+  draggable?: boolean;
+  /** 투명도 (0~1) */
+  opacity?: number;
+  /** z-index */
+  zIndex?: number;
+}
+
+export type { MarkerProps };

--- a/frontend/src/domains/maps/components/Marker/NumberMarker.tsx
+++ b/frontend/src/domains/maps/components/Marker/NumberMarker.tsx
@@ -41,7 +41,6 @@ const createNumberMarkerElement = (sequence: number): HTMLElement => {
  * @param props.position - 마커 위치 { lat, lng }
  * @param props.sequence - 표시할 숫자
  * @param props.onClick - 클릭 이벤트 핸들러
- * @param props.zIndex - z-index
  *
  * @example
  * ```tsx
@@ -54,12 +53,7 @@ const createNumberMarkerElement = (sequence: number): HTMLElement => {
  * </Map>
  * ```
  */
-const NumberMarker = ({
-  position,
-  sequence,
-  onClick,
-  zIndex,
-}: NumberMarkerProps) => {
+const NumberMarker = ({ position, sequence, onClick }: NumberMarkerProps) => {
   const map = useMap();
   const overlayRef = useRef<CustomOverlayInstanceType | null>(null);
   const contentRef = useRef<HTMLElement | null>(null);
@@ -80,7 +74,6 @@ const NumberMarker = ({
       content,
       xAnchor: 0.5,
       yAnchor: 0.5,
-      zIndex,
     });
 
     overlayRef.current = overlay;

--- a/frontend/src/domains/maps/components/Marker/NumberMarker.tsx
+++ b/frontend/src/domains/maps/components/Marker/NumberMarker.tsx
@@ -6,6 +6,9 @@ import type { CustomOverlayInstanceType } from '@/libs/map-sdk';
 
 import type { NumberMarkerProps } from './NumberMarker.types';
 
+// 🔬 리렌더링 측정용 (테스트 후 삭제)
+let numberMarkerRenderCount = 0;
+
 /**
  * 숫자 마커 요소 생성
  */
@@ -54,6 +57,10 @@ const createNumberMarkerElement = (sequence: number): HTMLElement => {
  * ```
  */
 const NumberMarker = memo(({ position, sequence, onClick }: NumberMarkerProps) => {
+  // 🔬 리렌더링 측정용 (테스트 후 삭제)
+  numberMarkerRenderCount += 1;
+  console.log(`[NumberMarker #${sequence}] render count: ${numberMarkerRenderCount}`);
+
   const map = useMap();
   const overlayRef = useRef<CustomOverlayInstanceType | null>(null);
   const contentRef = useRef<HTMLElement | null>(null);

--- a/frontend/src/domains/maps/components/Marker/NumberMarker.tsx
+++ b/frontend/src/domains/maps/components/Marker/NumberMarker.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useLayoutEffect, useRef, useMemo } from 'react';
+
+import { useMap } from '@/domains/maps/hooks/useMap';
+import { kakaoMapAdapter } from '@/libs/map-sdk';
+import type { CustomOverlayInstanceType } from '@/libs/map-sdk';
+
+import type { NumberMarkerProps } from './NumberMarker.types';
+
+/**
+ * 숫자 마커 요소 생성
+ */
+const createNumberMarkerElement = (sequence: number): HTMLElement => {
+  const content = document.createElement('div');
+  Object.assign(content.style, {
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '3rem',
+    height: '3rem',
+    borderRadius: '50%',
+    fontSize: '1.6rem',
+    fontWeight: 'bold',
+    color: 'white',
+    background: '#2b6cb0',
+  });
+  content.innerText = String(sequence);
+  return content;
+};
+
+/**
+ * 선언적 숫자 마커 컴포넌트
+ *
+ * @description
+ * 카카오 지도에 숫자가 표시된 마커를 선언적으로 렌더링하는 컴포넌트입니다.
+ * CustomOverlay를 사용하여 커스텀 스타일의 숫자 마커를 표시합니다.
+ * Map 컴포넌트의 자식으로 사용해야 합니다.
+ * 컴포넌트가 언마운트되면 마커가 자동으로 제거됩니다.
+ *
+ * @param props - 컴포넌트 Props
+ * @param props.position - 마커 위치 { lat, lng }
+ * @param props.sequence - 표시할 숫자
+ * @param props.onClick - 클릭 이벤트 핸들러
+ * @param props.zIndex - z-index
+ *
+ * @example
+ * ```tsx
+ * <Map center={{ lat: 37.5, lng: 127.0 }}>
+ *   <NumberMarker
+ *     position={{ lat: 37.5, lng: 127.0 }}
+ *     sequence={1}
+ *     onClick={() => console.log('clicked')}
+ *   />
+ * </Map>
+ * ```
+ */
+const NumberMarker = ({
+  position,
+  sequence,
+  onClick,
+  zIndex,
+}: NumberMarkerProps) => {
+  const map = useMap();
+  const overlayRef = useRef<CustomOverlayInstanceType | null>(null);
+  const contentRef = useRef<HTMLElement | null>(null);
+  const onClickRef = useRef(onClick);
+
+  // onClick ref 업데이트 (핸들러 변경 시 리스너 재등록 방지)
+  onClickRef.current = onClick;
+
+  // 마커 요소 메모이제이션 (sequence 변경 시에만 재생성)
+  const content = useMemo(() => createNumberMarkerElement(sequence), [sequence]);
+
+  // 오버레이 생성 (최초 1회 또는 sequence 변경 시)
+  useLayoutEffect(() => {
+    if (!map) return;
+
+    const overlay = kakaoMapAdapter.createCustomOverlay(map, {
+      position,
+      content,
+      xAnchor: 0.5,
+      yAnchor: 0.5,
+      zIndex,
+    });
+
+    overlayRef.current = overlay;
+    contentRef.current = content;
+
+    // cleanup: 오버레이 제거
+    return () => {
+      kakaoMapAdapter.removeCustomOverlay(overlay);
+      overlayRef.current = null;
+      contentRef.current = null;
+    };
+    // content가 변경되면 (sequence 변경) 오버레이 재생성
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, content]);
+
+  // position 변경 감지 → 위치 업데이트
+  useEffect(() => {
+    if (!overlayRef.current) return;
+
+    kakaoMapAdapter.setCustomOverlayPosition(overlayRef.current, position);
+    // position 객체 참조가 아닌 실제 좌표 값이 변경될 때만 실행
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [position.lat, position.lng]);
+
+  // click 이벤트 리스너
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const handleClick = () => {
+      onClickRef.current?.();
+    };
+
+    content.addEventListener('click', handleClick);
+
+    return () => {
+      content.removeEventListener('click', handleClick);
+    };
+  }, [content]); // content가 변경되면 리스너 재등록
+
+  // UI를 렌더링하지 않음
+  return null;
+};
+
+export default NumberMarker;

--- a/frontend/src/domains/maps/components/Marker/NumberMarker.tsx
+++ b/frontend/src/domains/maps/components/Marker/NumberMarker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useMemo } from 'react';
+import { memo, useEffect, useLayoutEffect, useRef, useMemo } from 'react';
 
 import { useMap } from '@/domains/maps/hooks/useMap';
 import { kakaoMapAdapter } from '@/libs/map-sdk';
@@ -53,7 +53,7 @@ const createNumberMarkerElement = (sequence: number): HTMLElement => {
  * </Map>
  * ```
  */
-const NumberMarker = ({ position, sequence, onClick }: NumberMarkerProps) => {
+const NumberMarker = memo(({ position, sequence, onClick }: NumberMarkerProps) => {
   const map = useMap();
   const overlayRef = useRef<CustomOverlayInstanceType | null>(null);
   const contentRef = useRef<HTMLElement | null>(null);
@@ -116,6 +116,16 @@ const NumberMarker = ({ position, sequence, onClick }: NumberMarkerProps) => {
 
   // UI를 렌더링하지 않음
   return null;
-};
+}, (prevProps, nextProps) => {
+  // true 반환 = 리렌더링 스킵
+  // onClick은 내부에서 ref로 처리하므로 비교하지 않음
+  return (
+    prevProps.position.lat === nextProps.position.lat &&
+    prevProps.position.lng === nextProps.position.lng &&
+    prevProps.sequence === nextProps.sequence
+  );
+});
+
+NumberMarker.displayName = 'NumberMarker';
 
 export default NumberMarker;

--- a/frontend/src/domains/maps/components/Marker/NumberMarker.types.ts
+++ b/frontend/src/domains/maps/components/Marker/NumberMarker.types.ts
@@ -1,0 +1,17 @@
+import type { LatLngLiteral } from '@/libs/map-sdk';
+
+/**
+ * NumberMarker 컴포넌트 Props
+ */
+interface NumberMarkerProps {
+  /** 마커 위치 */
+  position: LatLngLiteral;
+  /** 표시할 숫자 (sequence) */
+  sequence: number;
+  /** 클릭 이벤트 핸들러 */
+  onClick?: () => void;
+  /** z-index */
+  zIndex?: number;
+}
+
+export type { NumberMarkerProps };

--- a/frontend/src/domains/maps/components/Marker/NumberMarker.types.ts
+++ b/frontend/src/domains/maps/components/Marker/NumberMarker.types.ts
@@ -10,8 +10,6 @@ interface NumberMarkerProps {
   sequence: number;
   /** 클릭 이벤트 핸들러 */
   onClick?: () => void;
-  /** z-index */
-  zIndex?: number;
 }
 
 export type { NumberMarkerProps };

--- a/frontend/src/domains/maps/hooks/useMapMarkerControl.ts
+++ b/frontend/src/domains/maps/hooks/useMapMarkerControl.ts
@@ -2,14 +2,14 @@ import { useCallback, useRef } from 'react';
 
 import type {
   DrawMarkerProps,
-  MarkerType,
   MapRefType,
   CustomOverlayType,
 } from '@/domains/maps/types/api.types';
 import { createCustomMarkerElement } from '@/domains/maps/utils/createCustomMarkerElement';
 
 const useMapMarkerControl = (map: MapRefType) => {
-  const markersRef = useRef<(MarkerType | CustomOverlayType)[]>([]);
+  // 숫자 마커(CustomOverlay)만 관리 - 기본 마커는 Marker 컴포넌트에서 관리
+  const markersRef = useRef<CustomOverlayType[]>([]);
 
   const clearMarkers = useCallback(() => {
     markersRef.current.forEach((marker) => {
@@ -18,51 +18,40 @@ const useMapMarkerControl = (map: MapRefType) => {
     markersRef.current = [];
   }, []);
 
+  /**
+   * 숫자 마커 (routieSequence가 있는 경우)만 그립니다.
+   * 기본 마커는 Marker 컴포넌트로 선언적 렌더링합니다.
+   */
   const drawMarkers = useCallback(
     ({ place, routieSequence, onClick }: DrawMarkerProps) => {
       if (!map.current) return;
+
+      // routieSequence가 없으면 기본 마커 → Marker 컴포넌트에서 처리
+      if (!routieSequence) return;
 
       const position = new window.kakao.maps.LatLng(
         place.latitude,
         place.longitude,
       );
 
-      if (routieSequence) {
-        const content = createCustomMarkerElement(routieSequence);
+      const content = createCustomMarkerElement(routieSequence);
 
-        const overlay = new window.kakao.maps.CustomOverlay({
-          position,
-          content,
-          yAnchor: 0.5,
-          xAnchor: 0.5,
+      const overlay = new window.kakao.maps.CustomOverlay({
+        position,
+        content,
+        yAnchor: 0.5,
+        xAnchor: 0.5,
+      });
+
+      overlay.setMap(map.current);
+
+      if (onClick) {
+        content.addEventListener('click', () => {
+          onClick();
         });
-
-        overlay.setMap(map.current);
-
-        if (onClick) {
-          content.addEventListener('click', () => {
-            onClick();
-          });
-        }
-        markersRef.current.push(overlay);
-        return overlay;
-      } else {
-        const marker = new window.kakao.maps.Marker({
-          position,
-          title: place.name,
-        });
-
-        marker.setMap(map.current);
-
-        if (onClick) {
-          window.kakao.maps.event.addListener(marker, 'click', () => {
-            onClick();
-          });
-        }
-
-        markersRef.current.push(marker);
-        return marker;
       }
+      markersRef.current.push(overlay);
+      return overlay;
     },
     [map],
   );
@@ -87,6 +76,8 @@ const useMapMarkerControl = (map: MapRefType) => {
         }
       }, 100);
     },
+    // map은 ref 객체로 변경되지 않으므로 의존성에서 제외해도 안전함
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 
@@ -100,6 +91,8 @@ const useMapMarkerControl = (map: MapRefType) => {
         map.current.panTo(position);
       }
     }, 120);
+    // map은 ref 객체로 변경되지 않으므로 의존성에서 제외해도 안전함
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return { drawMarkers, fitBoundsToMarkers, clearMarkers, panToMarker };

--- a/frontend/src/domains/maps/hooks/useMapRenderer.ts
+++ b/frontend/src/domains/maps/hooks/useMapRenderer.ts
@@ -1,31 +1,19 @@
 import { useCallback } from 'react';
 
 import type { UseMapRendererProps } from '@/domains/maps/types/map.types';
-import type { PlaceDataType } from '@/domains/places/types/place.types';
 
 import { useMapNavigation } from './useMapNavigation';
-import { useMarkerRenderer } from './useMarkerRenderer';
 import { usePolylineRenderer } from './usePolylineRenderer';
 
 const useMapRenderer = ({
   mapRef,
   isInitialLoad,
   setIsInitialLoad,
-  handleMarkerClick,
-}: UseMapRendererProps) => {
-  const { handleInitialMapFitting, navigateToPlace } = useMapNavigation({
+}: Omit<UseMapRendererProps, 'handleMarkerClick'>) => {
+  const { handleInitialMapFitting } = useMapNavigation({
     mapRef,
     isInitialLoad,
     setIsInitialLoad,
-  });
-
-  const { renderMarkers } = useMarkerRenderer({
-    mapRef,
-    handleMarkerClick: (place: PlaceDataType) => {
-      // 마커 클릭 시: 오버레이 표시 + 맵 이동
-      handleMarkerClick(place);
-      navigateToPlace(place);
-    },
   });
 
   const { renderPolylines } = usePolylineRenderer({
@@ -36,12 +24,9 @@ const useMapRenderer = ({
     // 1. 맵 피팅 (첫 로드 시 또는 새로운 장소 추가 시)
     handleInitialMapFitting();
 
-    // 2. 마커 렌더링
-    renderMarkers();
-
-    // 3. 폴리라인 렌더링
+    // 2. 폴리라인 렌더링 (마커는 선언적 컴포넌트로 처리)
     renderPolylines();
-  }, [handleInitialMapFitting, renderMarkers, renderPolylines]);
+  }, [handleInitialMapFitting, renderPolylines]);
 
   return { renderMapElements };
 };

--- a/frontend/src/libs/map-sdk/__test__/MapSdkLoader.test.ts
+++ b/frontend/src/libs/map-sdk/__test__/MapSdkLoader.test.ts
@@ -19,6 +19,14 @@ const createMockAdapter = (
   createLatLng: vi.fn(),
   createMap: vi.fn(),
   relayout: vi.fn(),
+  createMarker: vi.fn(),
+  removeMarker: vi.fn(),
+  setMarkerPosition: vi.fn(),
+  addMarkerListener: vi.fn(),
+  removeMarkerListener: vi.fn(),
+  createCustomOverlay: vi.fn(),
+  removeCustomOverlay: vi.fn(),
+  setCustomOverlayPosition: vi.fn(),
 });
 
 describe('MapSdkLoader', () => {

--- a/frontend/src/libs/map-sdk/adapters/kakaoMapAdapter.ts
+++ b/frontend/src/libs/map-sdk/adapters/kakaoMapAdapter.ts
@@ -1,8 +1,14 @@
 import type {
+  CustomOverlayCreateOptions,
+  CustomOverlayInstanceType,
+  EventListenerType,
   LatLngInstanceType,
+  LatLngLiteral,
   MapAdapter,
   MapCreateOptions,
   MapInstanceType,
+  MarkerCreateOptions,
+  MarkerInstanceType,
 } from '../types/adapter.types';
 
 /**
@@ -91,6 +97,117 @@ const kakaoMapAdapter: MapAdapter = {
    */
   relayout(map: MapInstanceType): void {
     map.relayout();
+  },
+
+  /**
+   * 마커 생성
+   * @param map - 지도 인스턴스
+   * @param options - 마커 생성 옵션
+   */
+  createMarker(map: MapInstanceType, options: MarkerCreateOptions): MarkerInstanceType {
+    const position = this.createLatLng(options.position.lat, options.position.lng);
+
+    const marker = new window.kakao.maps.Marker({
+      position,
+      title: options.title,
+      clickable: options.clickable ?? true,
+      draggable: options.draggable ?? false,
+      opacity: options.opacity,
+      zIndex: options.zIndex,
+    });
+
+    marker.setMap(map);
+    return marker;
+  },
+
+  /**
+   * 마커 제거
+   * @param marker - 마커 인스턴스
+   */
+  removeMarker(marker: MarkerInstanceType): void {
+    marker.setMap(null);
+  },
+
+  /**
+   * 마커 위치 변경
+   * @param marker - 마커 인스턴스
+   * @param position - 새 위치
+   */
+  setMarkerPosition(marker: MarkerInstanceType, position: LatLngLiteral): void {
+    const newPosition = this.createLatLng(position.lat, position.lng);
+    marker.setPosition(newPosition);
+  },
+
+  /**
+   * 마커 이벤트 리스너 등록
+   * @param marker - 마커 인스턴스
+   * @param event - 이벤트 타입
+   * @param handler - 이벤트 핸들러
+   */
+  addMarkerListener(
+    marker: MarkerInstanceType,
+    event: string,
+    handler: EventListenerType,
+  ): void {
+    window.kakao.maps.event.addListener(marker, event, handler);
+  },
+
+  /**
+   * 마커 이벤트 리스너 제거
+   * @param marker - 마커 인스턴스
+   * @param event - 이벤트 타입
+   * @param handler - 이벤트 핸들러
+   */
+  removeMarkerListener(
+    marker: MarkerInstanceType,
+    event: string,
+    handler: EventListenerType,
+  ): void {
+    window.kakao.maps.event.removeListener(marker, event, handler);
+  },
+
+  /**
+   * 커스텀 오버레이 생성
+   * @param map - 지도 인스턴스
+   * @param options - 오버레이 생성 옵션
+   */
+  createCustomOverlay(
+    map: MapInstanceType,
+    options: CustomOverlayCreateOptions,
+  ): CustomOverlayInstanceType {
+    const position = this.createLatLng(options.position.lat, options.position.lng);
+
+    const overlay = new window.kakao.maps.CustomOverlay({
+      position,
+      content: options.content,
+      xAnchor: options.xAnchor ?? 0.5,
+      yAnchor: options.yAnchor ?? 0.5,
+      zIndex: options.zIndex,
+    });
+
+    overlay.setMap(map);
+    return overlay;
+  },
+
+  /**
+   * 커스텀 오버레이 제거
+   * @param overlay - 오버레이 인스턴스
+   */
+  removeCustomOverlay(overlay: CustomOverlayInstanceType): void {
+    overlay.setMap(null);
+  },
+
+  /**
+   * 커스텀 오버레이 위치 변경
+   * @param overlay - 오버레이 인스턴스
+   * @param position - 새 위치
+   */
+  setCustomOverlayPosition(
+    overlay: CustomOverlayInstanceType,
+    position: LatLngLiteral,
+  ): void {
+    const newPosition = this.createLatLng(position.lat, position.lng);
+    overlay.setPosition(newPosition);
   },
 };
 

--- a/frontend/src/libs/map-sdk/index.ts
+++ b/frontend/src/libs/map-sdk/index.ts
@@ -21,4 +21,9 @@ export type {
   LoaderStatus,
   LoaderSnapshot,
   LoaderOptions,
+  MarkerInstanceType,
+  MarkerCreateOptions,
+  EventListenerType,
+  CustomOverlayInstanceType,
+  CustomOverlayCreateOptions,
 } from './types/adapter.types';

--- a/frontend/src/libs/map-sdk/types/adapter.types.ts
+++ b/frontend/src/libs/map-sdk/types/adapter.types.ts
@@ -1,4 +1,10 @@
-import type { KakaoMap, KakaoLatLng } from '../../../../kakao.d';
+import type {
+  KakaoMap,
+  KakaoLatLng,
+  KakaoMarker,
+  KakaoCustomOverlay,
+  KakaoEventListener,
+} from '../../../../kakao.d';
 
 /**
  * 위경도 좌표 리터럴 타입
@@ -17,6 +23,55 @@ type MapInstanceType = KakaoMap;
  * LatLng 인스턴스 타입
  */
 type LatLngInstanceType = KakaoLatLng;
+
+/**
+ * 마커 인스턴스 타입
+ */
+type MarkerInstanceType = KakaoMarker;
+
+/**
+ * 이벤트 리스너 타입
+ */
+type EventListenerType = KakaoEventListener;
+
+/**
+ * 커스텀 오버레이 인스턴스 타입
+ */
+type CustomOverlayInstanceType = KakaoCustomOverlay;
+
+/**
+ * 커스텀 오버레이 생성 옵션
+ */
+interface CustomOverlayCreateOptions {
+  /** 오버레이 위치 */
+  position: LatLngLiteral;
+  /** 오버레이 내용 (HTML 요소) */
+  content: HTMLElement;
+  /** x축 기준점 (0~1) @default 0.5 */
+  xAnchor?: number;
+  /** y축 기준점 (0~1) @default 0.5 */
+  yAnchor?: number;
+  /** z-index */
+  zIndex?: number;
+}
+
+/**
+ * 마커 생성 옵션
+ */
+interface MarkerCreateOptions {
+  /** 마커 위치 */
+  position: LatLngLiteral;
+  /** 마커 제목 (툴팁) */
+  title?: string;
+  /** 클릭 가능 여부 @default true */
+  clickable?: boolean;
+  /** 드래그 가능 여부 @default false */
+  draggable?: boolean;
+  /** 투명도 (0~1) */
+  opacity?: number;
+  /** z-index */
+  zIndex?: number;
+}
 
 /**
  * 지도 생성 옵션
@@ -71,6 +126,76 @@ interface MapAdapter {
    * @param map - 지도 인스턴스
    */
   relayout(map: MapInstanceType): void;
+
+  /**
+   * 마커 생성
+   * @param map - 지도 인스턴스
+   * @param options - 마커 생성 옵션
+   */
+  createMarker(map: MapInstanceType, options: MarkerCreateOptions): MarkerInstanceType;
+
+  /**
+   * 마커 제거
+   * @param marker - 마커 인스턴스
+   */
+  removeMarker(marker: MarkerInstanceType): void;
+
+  /**
+   * 마커 위치 변경
+   * @param marker - 마커 인스턴스
+   * @param position - 새 위치
+   */
+  setMarkerPosition(marker: MarkerInstanceType, position: LatLngLiteral): void;
+
+  /**
+   * 마커 이벤트 리스너 등록
+   * @param marker - 마커 인스턴스
+   * @param event - 이벤트 타입
+   * @param handler - 이벤트 핸들러
+   */
+  addMarkerListener(
+    marker: MarkerInstanceType,
+    event: string,
+    handler: EventListenerType,
+  ): void;
+
+  /**
+   * 마커 이벤트 리스너 제거
+   * @param marker - 마커 인스턴스
+   * @param event - 이벤트 타입
+   * @param handler - 이벤트 핸들러
+   */
+  removeMarkerListener(
+    marker: MarkerInstanceType,
+    event: string,
+    handler: EventListenerType,
+  ): void;
+
+  /**
+   * 커스텀 오버레이 생성
+   * @param map - 지도 인스턴스
+   * @param options - 오버레이 생성 옵션
+   */
+  createCustomOverlay(
+    map: MapInstanceType,
+    options: CustomOverlayCreateOptions,
+  ): CustomOverlayInstanceType;
+
+  /**
+   * 커스텀 오버레이 제거
+   * @param overlay - 오버레이 인스턴스
+   */
+  removeCustomOverlay(overlay: CustomOverlayInstanceType): void;
+
+  /**
+   * 커스텀 오버레이 위치 변경
+   * @param overlay - 오버레이 인스턴스
+   * @param position - 새 위치
+   */
+  setCustomOverlayPosition(
+    overlay: CustomOverlayInstanceType,
+    position: LatLngLiteral,
+  ): void;
 }
 
 /**
@@ -107,4 +232,9 @@ export type {
   LoaderStatus,
   LoaderSnapshot,
   LoaderOptions,
+  MarkerInstanceType,
+  MarkerCreateOptions,
+  EventListenerType,
+  CustomOverlayInstanceType,
+  CustomOverlayCreateOptions,
 };


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 마커를 명령형으로 생성/삭제해서 React 상태와 동기화가 어렵고 clearMarkers() 수동 호출 필요
- window.kakao.maps 직접 사용으로 SDK 의존성이 코드 전체에 퍼져있음


## To-Be
<!-- 변경 사항 -->
- map-sdk에 마커 및 커스텀 오버레이 API 추가
- 선언적 `<Marker />`, `<NumberMarker />` 컴포넌트 구현
- 기존 명령형 마커 렌더링 로직을 선언적 컴포넌트로 전환

### 변경사항
#### map-sdk 확장
- `kakaoMapAdapter`에 마커/오버레이 CRUD 메서드 추가
  - `createMarker`, `removeMarker`, `setMarkerPosition`
  - `createCustomOverlay`, `removeCustomOverlay`, `setCustomOverlayPosition`
  - `addMarkerListener`, `removeMarkerListener`

#### 선언적 마커 컴포넌트
- `Marker` - 기본 마커 컴포넌트 (카카오 기본 마커 이미지)
- `NumberMarker` - 숫자 마커 컴포넌트 (루티 순서 표시용)
- 컴포넌트 언마운트 시 자동 정리 (cleanup)

#### 기존 훅 정리
- `useMapRenderer`에서 마커 렌더링 로직 제거
- `useMapMarkerControl` 린트 경고 수정

### Before / After

| Before (명령형) | After (선언적) |
|---|---|
| `drawMarkers({ place, ... })` | `<Marker position={...} />` |
| `clearMarkers()` 수동 호출 | 컴포넌트 언마운트 시 자동 정리 |
| `window.kakao.maps.Marker` 직접 사용 | `kakaoMapAdapter` 추상화 |



## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지도 마커의 상호작용성 개선 및 마커 선택 시 자동 네비게이션 기능 추가
  * 숫자 표시 마커 기능 추가

* **개선 사항**
  * 마커 렌더링 시스템 구조 개선으로 안정성 향상
  * 지도 SDK 기능 확대

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->