### PR TITLE
feat: map-sdk 오버레이/이벤트 레이어 추상화

### DIFF
--- a/frontend/src/domains/maps/components/KakaoMap/KakaoMap.tsx
+++ b/frontend/src/domains/maps/components/KakaoMap/KakaoMap.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 
 import Flex from '@/@common/components/Flex/Flex';
 import Text from '@/@common/components/Text/Text';
@@ -11,7 +10,7 @@ import { useCustomOverlay } from '@/domains/maps/hooks/useCustomOverlay';
 import { useMapRenderer } from '@/domains/maps/hooks/useMapRenderer';
 import { useMarkerItems } from '@/domains/maps/hooks/useMarkerItems';
 import type { PlaceDataType } from '@/domains/places/types/place.types';
-import { useMap, Map } from '@/libs/map-sdk';
+import { useMap, Map, OverlayLayer, MapEventLayer } from '@/libs/map-sdk';
 
 import MarkerLayer from '../MarkerLayer/MarkerLayer';
 import PolylineLayer from '../PolylineLayer/PolylineLayer';
@@ -66,18 +65,17 @@ const MapError = ({ error }: { error: Error }) => (
  * @param props.isSidebarOpen - 사이드바 열림 상태
  */
 const MapContent = ({ isSidebarOpen }: { isSidebarOpen: boolean }) => {
-  const map = useMap();
   const [isInitialLoad, setIsInitialLoad] = useState(true);
 
-  // 기존 훅들과 호환성을 위해 ref 패턴 유지
-  const mapRef = useRef<KakaoMapType | null>(null);
-  mapRef.current = map;
-
-  const { containerEl, openAt, close } = useCustomOverlay(mapRef);
+  const { containerEl, openAt, close, position } = useCustomOverlay();
   const { clickedPlace, handleMapClick, handleMarkerClick } = useClickedPlace({
     openAt,
     close,
   });
+  const map = useMap();
+  const mapRef = useRef<KakaoMapType | null>(null);
+  mapRef.current = map;
+
   const { renderMapElements, navigateToPlace } = useMapRenderer({
     mapRef,
     isInitialLoad,
@@ -92,17 +90,6 @@ const MapContent = ({ isSidebarOpen }: { isSidebarOpen: boolean }) => {
     },
     [handleMarkerClick, navigateToPlace],
   );
-
-  // 지도 클릭 이벤트 등록
-  useEffect(() => {
-    if (!map) return;
-
-    window.kakao.maps.event.addListener(map, 'click', handleMapClick);
-
-    return () => {
-      window.kakao.maps.event.removeListener(map, 'click', handleMapClick);
-    };
-  }, [map, handleMapClick]);
 
   // 맵 요소 렌더링 (마커, 폴리라인 등)
   useEffect(() => {
@@ -124,17 +111,29 @@ const MapContent = ({ isSidebarOpen }: { isSidebarOpen: boolean }) => {
   return (
     <>
       <HashtagFilter isSidebarOpen={isSidebarOpen} />
+      <MapEventLayer onClick={handleMapClick} />
       <MarkerLayer
         markerItems={markerItems}
         onMarkerClick={handleMarkerClickWithNavigate}
       />
       <PolylineLayer />
-      {containerEl &&
-        clickedPlace &&
-        createPortal(
-          <PlaceOverlayCard place={clickedPlace} onClose={handleMapClick} />,
-          containerEl,
-        )}
+      <OverlayLayer
+        overlayItem={
+          containerEl && position && clickedPlace
+            ? {
+                id: 'place-overlay',
+                position,
+                content: (
+                  <PlaceOverlayCard place={clickedPlace} onClose={handleMapClick} />
+                ),
+                xAnchor: 0.5,
+                yAnchor: 1,
+                zIndex: 3000,
+                clickable: true,
+              }
+            : null
+        }
+      />
     </>
   );
 };

--- a/frontend/src/domains/maps/hooks/useCustomOverlay.ts
+++ b/frontend/src/domains/maps/hooks/useCustomOverlay.ts
@@ -1,46 +1,26 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
-import type { MapRefType, CustomOverlayType } from '@/domains/maps/types/api.types';
+import type { UseCustomOverlayReturn } from '@/domains/maps/types/map.types';
 
-const useCustomOverlay = (map: MapRefType) => {
-  const overlayRef = useRef<CustomOverlayType | null>(null);
+const useCustomOverlay = (): UseCustomOverlayReturn => {
   const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
-
-  const openAt = useCallback(
-    (lat: number, lng: number) => {
-      if (!map.current) return;
-
-      if (overlayRef.current) {
-        overlayRef.current.setMap(null);
-        overlayRef.current = null;
-      }
-
-      const container = document.createElement('div');
-      container.style.pointerEvents = 'auto';
-      setContainerEl(container);
-
-      overlayRef.current = new window.kakao.maps.CustomOverlay({
-        position: new window.kakao.maps.LatLng(lat, lng),
-        yAnchor: 1,
-        xAnchor: 0.5,
-        zIndex: 3000,
-        content: container,
-        map: map.current,
-        clickable: true,
-      });
-    },
-    [map],
+  const [position, setPosition] = useState<{ lat: number; lng: number } | null>(
+    null,
   );
 
-  const close = useCallback(() => {
-    if (overlayRef.current) {
-      overlayRef.current.setMap(null);
-      overlayRef.current = null;
-    }
-    setContainerEl(null);
+  const openAt = useCallback((lat: number, lng: number) => {
+    const container = document.createElement('div');
+    container.style.pointerEvents = 'auto';
+    setContainerEl(container);
+    setPosition({ lat, lng });
   }, []);
 
-  return { openAt, close, containerEl };
+  const close = useCallback(() => {
+    setContainerEl(null);
+    setPosition(null);
+  }, []);
+
+  return { openAt, close, containerEl, position };
 };
 
 export { useCustomOverlay };

--- a/frontend/src/domains/maps/types/api.types.ts
+++ b/frontend/src/domains/maps/types/api.types.ts
@@ -4,7 +4,6 @@ import type { PlaceDataType } from '@/domains/places/types/place.types';
 
 type KakaoMapType = InstanceType<typeof window.kakao.maps.Map>;
 type MapStateType = 'loading' | 'ready' | 'error';
-type CustomOverlayType = InstanceType<typeof window.kakao.maps.CustomOverlay>;
 
 interface UseKakaoMapSDKReturnType {
   sdkReady: boolean;
@@ -33,7 +32,6 @@ type MapRefType = RefObject<KakaoMapType | null>;
 export type {
   KakaoMapType,
   MapStateType,
-  CustomOverlayType,
   UseKakaoMapSDKReturnType,
   UseKakaoMapInitProps,
   UseKakaoMapInitReturnType,

--- a/frontend/src/domains/maps/types/map.types.ts
+++ b/frontend/src/domains/maps/types/map.types.ts
@@ -42,6 +42,13 @@ interface PlaceOverlayCardProps {
   onClose: () => void;
 }
 
+interface UseCustomOverlayReturn {
+  openAt: (lat: number, lng: number) => void;
+  close: () => void;
+  containerEl: HTMLDivElement | null;
+  position: { lat: number; lng: number } | null;
+}
+
 export type {
   UseMapNavigationProps,
   UseMapRendererProps,
@@ -50,4 +57,5 @@ export type {
   UseClickedPlaceProps,
   UseClickedPlaceReturn,
   PlaceOverlayCardProps,
+  UseCustomOverlayReturn,
 };

--- a/frontend/src/libs/map-sdk/adapters/kakaoMapAdapter.ts
+++ b/frontend/src/libs/map-sdk/adapters/kakaoMapAdapter.ts
@@ -182,6 +182,7 @@ const kakaoMapAdapter: MapAdapter = {
     const overlay = new window.kakao.maps.CustomOverlay({
       position,
       content: options.content,
+      clickable: options.clickable,
       xAnchor: options.xAnchor ?? 0.5,
       yAnchor: options.yAnchor ?? 0.5,
       zIndex: options.zIndex,

--- a/frontend/src/libs/map-sdk/components/MapEventLayer/MapEventLayer.tsx
+++ b/frontend/src/libs/map-sdk/components/MapEventLayer/MapEventLayer.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+
+import { useMap } from '../../hooks/useMap';
+
+import type { MapEventLayerProps } from './MapEventLayer.types';
+
+interface MapEventEntry {
+  event: 'click' | 'dragend' | 'zoom_changed';
+  handler: MapEventLayerProps[keyof MapEventLayerProps];
+}
+
+const MapEventLayer = ({ onClick, onDragEnd, onZoomChanged }: MapEventLayerProps) => {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map) return;
+
+    const entries: MapEventEntry[] = [
+      { event: 'click', handler: onClick },
+      { event: 'dragend', handler: onDragEnd },
+      { event: 'zoom_changed', handler: onZoomChanged },
+    ];
+
+    const activeEntries = entries.filter(
+      (entry): entry is MapEventEntry & { handler: () => void } =>
+        typeof entry.handler === 'function',
+    );
+
+    activeEntries.forEach((entry) => {
+      window.kakao.maps.event.addListener(map, entry.event, entry.handler);
+    });
+
+    return () => {
+      activeEntries.forEach((entry) => {
+        window.kakao.maps.event.removeListener(map, entry.event, entry.handler);
+      });
+    };
+  }, [map, onClick, onDragEnd, onZoomChanged]);
+
+  return null;
+};
+
+export default MapEventLayer;

--- a/frontend/src/libs/map-sdk/components/MapEventLayer/MapEventLayer.types.ts
+++ b/frontend/src/libs/map-sdk/components/MapEventLayer/MapEventLayer.types.ts
@@ -1,0 +1,9 @@
+type MapEventHandlerType = () => void;
+
+interface MapEventLayerProps {
+  onClick?: MapEventHandlerType;
+  onDragEnd?: MapEventHandlerType;
+  onZoomChanged?: MapEventHandlerType;
+}
+
+export type { MapEventHandlerType, MapEventLayerProps };

--- a/frontend/src/libs/map-sdk/components/MapEventLayer/__tests__/MapEventLayer.test.tsx
+++ b/frontend/src/libs/map-sdk/components/MapEventLayer/__tests__/MapEventLayer.test.tsx
@@ -1,0 +1,65 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import MapEventLayer from '@/libs/map-sdk/components/MapEventLayer/MapEventLayer';
+import * as useMapModule from '@/libs/map-sdk/hooks/useMap';
+
+import type { KakaoMap } from '../../../../../../kakao.d';
+
+const createMockMap = () =>
+  ({
+    getCenter: vi.fn(),
+    getLevel: vi.fn(),
+  }) as unknown as KakaoMap;
+
+describe('MapEventLayer', () => {
+  const mockMap = createMockMap();
+  const addListener = vi.fn();
+  const removeListener = vi.fn();
+
+  beforeEach(() => {
+    vi.spyOn(useMapModule, 'useMap').mockReturnValue(mockMap);
+
+    window.kakao = {
+      maps: {
+        event: {
+          addListener,
+          removeListener,
+        },
+      },
+    } as unknown as typeof window.kakao;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('전달된 이벤트 핸들러를 등록한다', () => {
+    const onClick = vi.fn();
+    const onDragEnd = vi.fn();
+
+    render(<MapEventLayer onClick={onClick} onDragEnd={onDragEnd} />);
+
+    expect(addListener).toHaveBeenCalledWith(mockMap, 'click', onClick);
+    expect(addListener).toHaveBeenCalledWith(mockMap, 'dragend', onDragEnd);
+    expect(addListener).toHaveBeenCalledTimes(2);
+  });
+
+  it('언마운트 시 등록된 이벤트 핸들러를 제거한다', () => {
+    const onClick = vi.fn();
+    const onZoomChanged = vi.fn();
+
+    const { unmount } = render(
+      <MapEventLayer onClick={onClick} onZoomChanged={onZoomChanged} />,
+    );
+
+    unmount();
+
+    expect(removeListener).toHaveBeenCalledWith(mockMap, 'click', onClick);
+    expect(removeListener).toHaveBeenCalledWith(
+      mockMap,
+      'zoom_changed',
+      onZoomChanged,
+    );
+  });
+});

--- a/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.tsx
+++ b/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { kakaoMapAdapter } from '../../adapters/kakaoMapAdapter';
@@ -19,7 +19,7 @@ const getOptionsKey = (item: OverlayItemType) =>
 const OverlayLayer = ({ overlayItem }: OverlayLayerProps) => {
   const map = useMap();
   const overlayRef = useRef<CustomOverlayInstanceType | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
   const prevOptionsKeyRef = useRef<string | null>(null);
   const prevPositionKeyRef = useRef<string | null>(null);
 
@@ -29,7 +29,7 @@ const OverlayLayer = ({ overlayItem }: OverlayLayerProps) => {
         kakaoMapAdapter.removeCustomOverlay(overlayRef.current);
         overlayRef.current = null;
       }
-      containerRef.current = null;
+      setContainerEl(null);
       prevOptionsKeyRef.current = null;
       prevPositionKeyRef.current = null;
     };
@@ -41,7 +41,7 @@ const OverlayLayer = ({ overlayItem }: OverlayLayerProps) => {
         kakaoMapAdapter.removeCustomOverlay(overlayRef.current);
         overlayRef.current = null;
       }
-      containerRef.current = null;
+      setContainerEl(null);
       prevOptionsKeyRef.current = null;
       prevPositionKeyRef.current = null;
       return;
@@ -54,7 +54,7 @@ const OverlayLayer = ({ overlayItem }: OverlayLayerProps) => {
       const container = document.createElement('div');
       container.style.pointerEvents =
         overlayItem.clickable === false ? 'none' : 'auto';
-      containerRef.current = container;
+      setContainerEl(container);
 
       overlayRef.current = kakaoMapAdapter.createCustomOverlay(map, {
         position: overlayItem.position,
@@ -70,15 +70,15 @@ const OverlayLayer = ({ overlayItem }: OverlayLayerProps) => {
       return;
     }
 
-    if (prevOptionsKeyRef.current !== optionsKey && containerRef.current) {
+    if (prevOptionsKeyRef.current !== optionsKey && containerEl) {
       kakaoMapAdapter.removeCustomOverlay(overlayRef.current);
 
-      containerRef.current.style.pointerEvents =
+      containerEl.style.pointerEvents =
         overlayItem.clickable === false ? 'none' : 'auto';
 
       overlayRef.current = kakaoMapAdapter.createCustomOverlay(map, {
         position: overlayItem.position,
-        content: containerRef.current,
+        content: containerEl,
         xAnchor: overlayItem.xAnchor,
         yAnchor: overlayItem.yAnchor,
         zIndex: overlayItem.zIndex,
@@ -97,14 +97,14 @@ const OverlayLayer = ({ overlayItem }: OverlayLayerProps) => {
       );
       prevPositionKeyRef.current = positionKey;
     }
-  }, [map, overlayItem]);
+  }, [map, overlayItem, containerEl]);
 
   const overlayContent = useMemo(() => overlayItem?.content ?? null, [overlayItem]);
 
   return (
     <>
-      {overlayContent && containerRef.current
-        ? createPortal(overlayContent, containerRef.current)
+      {overlayContent && containerEl
+        ? createPortal(overlayContent, containerEl)
         : null}
     </>
   );

--- a/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.tsx
+++ b/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.tsx
@@ -1,7 +1,113 @@
-import type { OverlayLayerProps } from './OverlayLayer.types';
+import { useEffect, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 
-const OverlayLayer = (_props: OverlayLayerProps) => {
-  return null;
+import { kakaoMapAdapter } from '../../adapters/kakaoMapAdapter';
+import { useMap } from '../../hooks/useMap';
+
+import type { OverlayLayerProps } from './OverlayLayer.types';
+import type { CustomOverlayInstanceType, LatLngLiteral } from '../../types/adapter.types';
+import type { OverlayItemType } from '../../types/overlay.types';
+
+const getPositionKey = (position: LatLngLiteral) =>
+  `${position.lat},${position.lng}`;
+
+const getOptionsKey = (item: OverlayItemType) =>
+  `${item.xAnchor ?? 0.5}-${item.yAnchor ?? 0.5}-${item.zIndex ?? 'none'}-${
+    item.clickable ?? 'none'
+  }`;
+
+const OverlayLayer = ({ overlayItem }: OverlayLayerProps) => {
+  const map = useMap();
+  const overlayRef = useRef<CustomOverlayInstanceType | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const prevOptionsKeyRef = useRef<string | null>(null);
+  const prevPositionKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (overlayRef.current) {
+        kakaoMapAdapter.removeCustomOverlay(overlayRef.current);
+        overlayRef.current = null;
+      }
+      containerRef.current = null;
+      prevOptionsKeyRef.current = null;
+      prevPositionKeyRef.current = null;
+    };
+  }, [map]);
+
+  useEffect(() => {
+    if (!map || !overlayItem) {
+      if (overlayRef.current) {
+        kakaoMapAdapter.removeCustomOverlay(overlayRef.current);
+        overlayRef.current = null;
+      }
+      containerRef.current = null;
+      prevOptionsKeyRef.current = null;
+      prevPositionKeyRef.current = null;
+      return;
+    }
+
+    const positionKey = getPositionKey(overlayItem.position);
+    const optionsKey = getOptionsKey(overlayItem);
+
+    if (!overlayRef.current) {
+      const container = document.createElement('div');
+      container.style.pointerEvents =
+        overlayItem.clickable === false ? 'none' : 'auto';
+      containerRef.current = container;
+
+      overlayRef.current = kakaoMapAdapter.createCustomOverlay(map, {
+        position: overlayItem.position,
+        content: container,
+        xAnchor: overlayItem.xAnchor,
+        yAnchor: overlayItem.yAnchor,
+        zIndex: overlayItem.zIndex,
+        clickable: overlayItem.clickable,
+      });
+
+      prevOptionsKeyRef.current = optionsKey;
+      prevPositionKeyRef.current = positionKey;
+      return;
+    }
+
+    if (prevOptionsKeyRef.current !== optionsKey && containerRef.current) {
+      kakaoMapAdapter.removeCustomOverlay(overlayRef.current);
+
+      containerRef.current.style.pointerEvents =
+        overlayItem.clickable === false ? 'none' : 'auto';
+
+      overlayRef.current = kakaoMapAdapter.createCustomOverlay(map, {
+        position: overlayItem.position,
+        content: containerRef.current,
+        xAnchor: overlayItem.xAnchor,
+        yAnchor: overlayItem.yAnchor,
+        zIndex: overlayItem.zIndex,
+        clickable: overlayItem.clickable,
+      });
+
+      prevOptionsKeyRef.current = optionsKey;
+      prevPositionKeyRef.current = positionKey;
+      return;
+    }
+
+    if (prevPositionKeyRef.current !== positionKey && overlayRef.current) {
+      kakaoMapAdapter.setCustomOverlayPosition(
+        overlayRef.current,
+        overlayItem.position,
+      );
+      prevPositionKeyRef.current = positionKey;
+    }
+  }, [map, overlayItem]);
+
+  const overlayContent = useMemo(() => overlayItem?.content ?? null, [overlayItem]);
+
+  return (
+    <>
+      {overlayContent && containerRef.current
+        ? createPortal(overlayContent, containerRef.current)
+        : null}
+    </>
+  );
 };
 
 export default OverlayLayer;

--- a/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.tsx
+++ b/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.tsx
@@ -1,0 +1,7 @@
+import type { OverlayLayerProps } from './OverlayLayer.types';
+
+const OverlayLayer = (_props: OverlayLayerProps) => {
+  return null;
+};
+
+export default OverlayLayer;

--- a/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.types.ts
+++ b/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.types.ts
@@ -1,7 +1,7 @@
-import type { OverlayItemListType } from '../../types/overlay.types';
+import type { OverlayItemType } from '../../types/overlay.types';
 
 interface OverlayLayerProps {
-  overlayItemList: OverlayItemListType;
+  overlayItem: OverlayItemType | null;
 }
 
 export type { OverlayLayerProps };

--- a/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.types.ts
+++ b/frontend/src/libs/map-sdk/components/OverlayLayer/OverlayLayer.types.ts
@@ -1,0 +1,7 @@
+import type { OverlayItemListType } from '../../types/overlay.types';
+
+interface OverlayLayerProps {
+  overlayItemList: OverlayItemListType;
+}
+
+export type { OverlayLayerProps };

--- a/frontend/src/libs/map-sdk/components/OverlayLayer/__tests__/OverlayLayer.test.tsx
+++ b/frontend/src/libs/map-sdk/components/OverlayLayer/__tests__/OverlayLayer.test.tsx
@@ -1,0 +1,103 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { kakaoMapAdapter } from '@/libs/map-sdk/adapters/kakaoMapAdapter';
+import OverlayLayer from '@/libs/map-sdk/components/OverlayLayer/OverlayLayer';
+import * as useMapModule from '@/libs/map-sdk/hooks/useMap';
+
+import type { KakaoMap } from '../../../../../../kakao.d';
+
+vi.mock('@/libs/map-sdk/adapters/kakaoMapAdapter', () => ({
+  kakaoMapAdapter: {
+    createCustomOverlay: vi.fn(),
+    removeCustomOverlay: vi.fn(),
+    setCustomOverlayPosition: vi.fn(),
+  },
+}));
+
+const createMockMap = () =>
+  ({
+    getCenter: vi.fn(),
+    getLevel: vi.fn(),
+  }) as unknown as KakaoMap;
+
+describe('OverlayLayer', () => {
+  const mockMap = createMockMap();
+  const mockOverlay = {};
+
+  beforeEach(() => {
+    vi.spyOn(useMapModule, 'useMap').mockReturnValue(mockMap);
+    vi.mocked(kakaoMapAdapter.createCustomOverlay).mockReturnValue(mockOverlay as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('map이 준비되면 오버레이를 생성한다', () => {
+    const overlayItem = {
+      id: 1,
+      position: { lat: 37.5, lng: 127.0 },
+      content: <div>content</div>,
+      xAnchor: 0.5,
+      yAnchor: 1,
+      zIndex: 100,
+      clickable: true,
+    };
+
+    render(<OverlayLayer overlayItem={overlayItem} />);
+
+    expect(kakaoMapAdapter.createCustomOverlay).toHaveBeenCalledTimes(1);
+    const [mapArg, optionsArg] = vi.mocked(
+      kakaoMapAdapter.createCustomOverlay,
+    ).mock.calls[0];
+    expect(mapArg).toBe(mockMap);
+    expect(optionsArg.position).toEqual(overlayItem.position);
+    expect(optionsArg.xAnchor).toBe(0.5);
+    expect(optionsArg.yAnchor).toBe(1);
+    expect(optionsArg.zIndex).toBe(100);
+    expect(optionsArg.clickable).toBe(true);
+    expect(optionsArg.content).toBeInstanceOf(HTMLElement);
+  });
+
+  it('position이 변경되면 setCustomOverlayPosition을 호출한다', () => {
+    const overlayItem = {
+      id: 1,
+      position: { lat: 37.5, lng: 127.0 },
+      content: <div>content</div>,
+    };
+
+    const { rerender } = render(
+      <OverlayLayer overlayItem={overlayItem} />,
+    );
+
+    const nextOverlayItem = {
+      id: 1,
+      position: { lat: 37.6, lng: 127.1 },
+      content: <div>content</div>,
+    };
+
+    rerender(<OverlayLayer overlayItem={nextOverlayItem} />);
+
+    expect(kakaoMapAdapter.setCustomOverlayPosition).toHaveBeenCalledWith(
+      mockOverlay,
+      nextOverlayItem.position,
+    );
+  });
+
+  it('overlayItem이 제거되면 오버레이를 제거한다', () => {
+    const overlayItem = {
+      id: 1,
+      position: { lat: 37.5, lng: 127.0 },
+      content: <div>content</div>,
+    };
+
+    const { rerender } = render(
+      <OverlayLayer overlayItem={overlayItem} />,
+    );
+
+    rerender(<OverlayLayer overlayItem={null} />);
+
+    expect(kakaoMapAdapter.removeCustomOverlay).toHaveBeenCalledWith(mockOverlay);
+  });
+});

--- a/frontend/src/libs/map-sdk/index.ts
+++ b/frontend/src/libs/map-sdk/index.ts
@@ -43,3 +43,4 @@ export type {
   PolylineCreateOptions,
 } from './types/adapter.types';
 
+export type { OverlayItemType, OverlayItemListType } from './types/overlay.types';

--- a/frontend/src/libs/map-sdk/index.ts
+++ b/frontend/src/libs/map-sdk/index.ts
@@ -20,6 +20,8 @@ export { default as Polyline } from './components/Polyline/Polyline';
 export type { PolylineProps } from './components/Polyline/Polyline.types';
 export { default as OverlayLayer } from './components/OverlayLayer/OverlayLayer';
 export type { OverlayLayerProps } from './components/OverlayLayer/OverlayLayer.types';
+export { default as MapEventLayer } from './components/MapEventLayer/MapEventLayer';
+export type { MapEventLayerProps } from './components/MapEventLayer/MapEventLayer.types';
 
 // Hooks
 export { useMapSdkLoader } from './hooks/useMapSdkLoader';

--- a/frontend/src/libs/map-sdk/index.ts
+++ b/frontend/src/libs/map-sdk/index.ts
@@ -18,6 +18,8 @@ export { default as NumberMarker } from './components/NumberMarker/NumberMarker'
 export type { NumberMarkerProps } from './components/NumberMarker/NumberMarker.types';
 export { default as Polyline } from './components/Polyline/Polyline';
 export type { PolylineProps } from './components/Polyline/Polyline.types';
+export { default as OverlayLayer } from './components/OverlayLayer/OverlayLayer';
+export type { OverlayLayerProps } from './components/OverlayLayer/OverlayLayer.types';
 
 // Hooks
 export { useMapSdkLoader } from './hooks/useMapSdkLoader';
@@ -43,4 +45,7 @@ export type {
   PolylineCreateOptions,
 } from './types/adapter.types';
 
-export type { OverlayItemType, OverlayItemListType } from './types/overlay.types';
+export type {
+  OverlayItemType,
+  OverlayItemListType,
+} from './types/overlay.types';

--- a/frontend/src/libs/map-sdk/index.ts
+++ b/frontend/src/libs/map-sdk/index.ts
@@ -45,7 +45,4 @@ export type {
   PolylineCreateOptions,
 } from './types/adapter.types';
 
-export type {
-  OverlayItemType,
-  OverlayItemListType,
-} from './types/overlay.types';
+export type { OverlayItemType } from './types/overlay.types';

--- a/frontend/src/libs/map-sdk/types/adapter.types.ts
+++ b/frontend/src/libs/map-sdk/types/adapter.types.ts
@@ -69,6 +69,8 @@ interface CustomOverlayCreateOptions {
   position: LatLngLiteral;
   /** 오버레이 내용 (HTML 요소) */
   content: HTMLElement;
+  /** 클릭 가능 여부 @default false */
+  clickable?: boolean;
   /** x축 기준점 (0~1) @default 0.5 */
   xAnchor?: number;
   /** y축 기준점 (0~1) @default 0.5 */

--- a/frontend/src/libs/map-sdk/types/overlay.types.ts
+++ b/frontend/src/libs/map-sdk/types/overlay.types.ts
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+import type { LatLngLiteral } from './adapter.types';
+
+interface OverlayItemType {
+  id: string | number;
+  position: LatLngLiteral;
+  content: ReactNode;
+  xAnchor?: number;
+  yAnchor?: number;
+  zIndex?: number;
+  clickable?: boolean;
+}
+
+type OverlayItemListType = OverlayItemType[];
+
+export type { OverlayItemType, OverlayItemListType };

--- a/frontend/src/libs/map-sdk/types/overlay.types.ts
+++ b/frontend/src/libs/map-sdk/types/overlay.types.ts
@@ -12,6 +12,4 @@ interface OverlayItemType {
   clickable?: boolean;
 }
 
-type OverlayItemListType = OverlayItemType[];
-
-export type { OverlayItemType, OverlayItemListType };
+export type { OverlayItemType };


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- 도메인에서 CustomOverlay 생성/이벤트 등록을 직접 처리하고 있었음
- 오버레이 렌더링이 map-sdk로 추상화되어 있지 않았음

## To-Be
<!-- 변경 사항 -->
- map-sdk에 OverlayLayer/MapEventLayer 추가
  - OverlayLayer: CustomOverlay 생성/업데이트/제거 및 portal 렌더링을 전담하는 레이어
  - MapEventLayer: 지도 이벤트(add/remove)를 중앙에서 관리해 도메인에서 window.kakao 접근을 제거
- 도메인 오버레이 로직을 상태 관리로 단순화하고 map-sdk에 위임
- 오버레이 렌더링을 단일 오버레이 기준으로 정리
- 관련 타입/테스트 보강

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
로컬에서 잘 동작합니다
<img width="1396" height="1005" alt="image" src="https://github.com/user-attachments/assets/28e01dc2-690b-42fa-b7ef-273073b88ade" />

## (Optional) Additional Description
- 오버레이 렌더링을 배열로 해서 여러개의 오버레이가 열리는 경우로 할까, 우리 서비스 처럼 한 번의 하나의 오버레이만 열리게 할까 고민했는데  
우선 루티에 맞게 단일 오버레이 기준으로 구현했습니다. 혹시 확장가능성으로 두고 배열로 구현하는게 더 나을까요? 의견 부탁드립니다.
- MapEventLayer에서 이벤트는 현재 onClick/onDragEnd/onZoomChanged까지 열어뒀습니다. 실제로 onClick만 필요하긴 한데 onClick만 남겨두는게 더 나을까요..?

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
Closes #1077 