### PR TITLE
feat: SEO 개선

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,2 +1,3 @@
 .eslintrc.cjs
 public/mockServiceWorker.js
+scripts/**/*.mjs

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -131,6 +131,7 @@ module.exports = {
   },
   ignorePatterns: [
     'dist',
+    'scripts/**/*.mjs',
     'webpack.common.js',
     'webpack.dev.js',
     'webpack.prod.js',

--- a/frontend/.github/workflows/ci.yml
+++ b/frontend/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run lint
 
       - name: Run Build
-        run: npm run build
+        run: npm run build:prod
 
       - name: Run Test
         run: npm test

--- a/frontend/.stylelintignore
+++ b/frontend/.stylelintignore
@@ -1,1 +1,2 @@
 .eslintrc.cjs
+scripts/**/*.mjs

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "start": "webpack serve --mode development --config webpack.dev.js",
     "build:dev": "webpack --mode development --config webpack.dev.js",
+    "generate:sitemap": "node scripts/generate-sitemap.mjs",
+    "prebuild:prod": "npm run generate:sitemap",
     "build:prod": "webpack --mode production --config webpack.prod.js",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,6 +5,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <!-- Google Search Console 인증 -->
+    <meta
+      name="google-site-verification"
+      content="gUFBiCBDfbo2JQX3vLnvplHvcWq8NOdYg2eoUtCS7Zo"
+    />
+
     <!-- Primary SEO -->
     <title>루티(Routie) - 친구들과 함께 여행 동선을 계획하세요</title>
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,20 +1,25 @@
 <!doctype html>
 <html lang="ko">
   <head>
+    <!-- Basic -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <!-- Primary SEO -->
     <title>루티(Routie) - 친구들과 함께 여행 동선을 계획하세요</title>
 
     <!-- canonical: 이 페이지의 대표 URL 지정. 중복 URL로 인한 SEO 점수 분산 방지. -->
     <link rel="canonical" href="https://routie.me/" />
-
+    <!-- 검색 결과에 노출되는 페이지 설명 (클릭률에 영향) -->
     <meta
       name="description"
       content="루티에서 친구들과 장소를 추가하고 여행 동선을 계획하세요. 여행 일정 정리와 공유를 간편하게 도와줍니다."
     />
+    <!-- 검색엔진에 인덱싱 및 링크 추적 허용 -->
+    <!-- 기본값이 이거여서 명시하지 않아도 동일하게 동작하는데 일단 명시 -->
+    <meta name="robots" content="index, follow" />
 
-    <!-- Favicon -->
+    <!-- App Icons -->
     <link
       rel="icon"
       type="image/png"
@@ -28,12 +33,12 @@
       sizes="180x180"
       href="/favicon/apple-touch-icon.png"
     />
-    <meta name="apple-mobile-web-app-title" content="Routie" />
+    <meta name="apple-mobile-web-app-title" content="루티(Routie)" />
 
     <!-- Open Graph -->
     <meta
       property="og:description"
-      content="루티를 사용해 친구들과 함께 동선을 만들어보세요"
+      content="루티에서 친구들과 장소를 추가하고 여행 동선을 계획하세요. 여행 일정 정리와 공유를 간편하게 도와줍니다."
     />
     <meta property="og:url" content="https://routie.me/" />
     <meta
@@ -42,11 +47,45 @@
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Routie" />
-    <meta property="og:title" content="Routie" />
+    <meta property="og:image:alt" content="루티(Routie)" />
+    <meta
+      property="og:title"
+      content="루티(Routie) - 친구들과 함께 여행 동선을 계획하세요"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
-    <meta property="og:site_name" content="Routie" />
+    <meta property="og:site_name" content="루티(Routie)" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="루티(Routie) - 친구들과 함께 여행 동선을 계획하세요"
+    />
+    <meta
+      name="twitter:description"
+      content="루티에서 친구들과 장소를 추가하고 여행 동선을 계획하세요. 여행 일정 정리와 공유를 간편하게 도와줍니다."
+    />
+    <meta
+      name="twitter:image"
+      content="https://routie.me/images/routie-og.png"
+    />
+
+    <!-- Structured Data -->
+    <!-- 검색엔진이 사이트 정보를 구조적으로 이해하도록 도움 -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "루티",
+        "alternateName": "Routie",
+        "url": "https://routie.me/",
+        "inLanguage": "ko-KR",
+        "description": "루티에서 친구들과 장소를 추가하고 여행 동선을 계획하세요. 여행 일정 정리와 공유를 간편하게 도와줍니다."
+      }
+    </script>
+
+    <!-- Web App Manifest -->
     <link rel="manifest" href="/favicon/site.webmanifest" />
   </head>
   <body>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,6 +1,20 @@
-<!DOCTYPE html>
-<html lang="en">
+<!doctype html>
+<html lang="ko">
   <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>루티(Routie) - 친구들과 함께 여행 동선을 계획하세요</title>
+
+    <!-- canonical: 이 페이지의 대표 URL 지정. 중복 URL로 인한 SEO 점수 분산 방지. -->
+    <link rel="canonical" href="https://routie.me/" />
+
+    <meta
+      name="description"
+      content="루티에서 친구들과 장소를 추가하고 여행 동선을 계획하세요. 여행 일정 정리와 공유를 간편하게 도와줍니다."
+    />
+
+    <!-- Favicon -->
     <link
       rel="icon"
       type="image/png"
@@ -15,15 +29,13 @@
       href="/favicon/apple-touch-icon.png"
     />
     <meta name="apple-mobile-web-app-title" content="Routie" />
-    <meta
-      name="description"
-      content="루티를 사용해 친구들과 함께 동선을 만들어보세요"
-    />
+
+    <!-- Open Graph -->
     <meta
       property="og:description"
       content="루티를 사용해 친구들과 함께 동선을 만들어보세요"
     />
-    <meta property="og:url" content="https://routie.me" />
+    <meta property="og:url" content="https://routie.me/" />
     <meta
       property="og:image"
       content="https://routie.me/images/routie-og.png"
@@ -36,9 +48,6 @@
     <meta property="og:locale" content="ko_KR" />
     <meta property="og:site_name" content="Routie" />
     <link rel="manifest" href="/favicon/site.webmanifest" />
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Routie</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -12,7 +12,7 @@
     />
 
     <!-- Primary SEO -->
-    <title>루티(Routie) - 친구들과 함께 여행 동선을 계획하세요</title>
+    <title>루티 Routie | 친구들과 여행 동선을 함께 계획하고 공유해요</title>
 
     <!-- canonical: 이 페이지의 대표 URL 지정. 중복 URL로 인한 SEO 점수 분산 방지. -->
     <link rel="canonical" href="https://routie.me/" />
@@ -56,7 +56,7 @@
     <meta property="og:image:alt" content="루티(Routie)" />
     <meta
       property="og:title"
-      content="루티(Routie) - 친구들과 함께 여행 동선을 계획하세요"
+      content="루티 Routie | 친구들과 여행 동선을 함께 계획하고 공유해요"
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
@@ -66,7 +66,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="루티(Routie) - 친구들과 함께 여행 동선을 계획하세요"
+      content="루티 Routie | 친구들과 여행 동선을 함께 계획하고 공유해요"
     />
     <meta
       name="twitter:description"
@@ -76,6 +76,8 @@
       name="twitter:image"
       content="https://routie.me/images/routie-og.png"
     />
+    <meta name="twitter:url" content="https://routie.me/" />
+    <meta name="twitter:image:alt" content="루티 Routie 서비스 대표 이미지" />
 
     <!-- Structured Data -->
     <!-- 검색엔진이 사이트 정보를 구조적으로 이해하도록 도움 -->

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -2,3 +2,5 @@ User-agent: *
 Allow: /
 Disallow: /auth/
 Disallow: /manage-routie-spaces
+
+Sitemap: https://routie.me/sitemap.xml

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+Disallow: /auth/
+Disallow: /manage-routie-spaces

--- a/frontend/scripts/generate-sitemap.mjs
+++ b/frontend/scripts/generate-sitemap.mjs
@@ -1,0 +1,66 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// 기본 도메인은 운영 주소를 사용하고, 필요하면 CI/스테이징에서 환경변수로 덮어쓴다.
+const SITE_URL = process.env.SITEMAP_SITE_URL || 'https://routie.me';
+// 검색 인덱싱 대상인 공개 정적 라우트만 유지한다.
+const STATIC_PATHS = ['/', '/routie-spaces', '/version'];
+// 동적 라우트 사이트맵은 현재 비활성화 상태다.
+// 추후 운영 시점에 공개 가능한 식별자 목록 + 실제 updatedAt(lastmod)을
+// 백엔드에서 조회한 뒤 sitemap 항목으로 병합하는 방식으로 확장한다.
+const GENERATED_AT = new Date().toISOString();
+
+const escapeXml = (value) => {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+};
+
+const createUrlNode = ({ path, lastmod }) => {
+  return [
+    '  <url>',
+    `    <loc>${escapeXml(`${SITE_URL}${path}`)}</loc>`,
+    `    <lastmod>${lastmod}</lastmod>`,
+    '  </url>',
+  ].join('\n');
+};
+
+const createStaticEntries = () => {
+  return STATIC_PATHS.map((path) => ({
+    path,
+    lastmod: GENERATED_AT,
+  }));
+};
+
+// TODO: 동적 라우트 사이트맵 확장 시 아래 로직을 활성화한다.
+// const createDynamicEntries = (dynamicSpaces) => {
+//   return dynamicSpaces.map((space) => ({
+//     path: `/routie-spaces?routieSpaceIdentifier=${encodeURIComponent(space.id)}`,
+//     lastmod: space.updatedAt,
+//   }));
+// };
+
+const createSitemapXml = () => {
+  // 현재는 정적 라우트만 포함한다.
+  // 추후: [...createStaticEntries(), ...createDynamicEntries(dynamicSpaces)]
+  const sitemapEntries = createStaticEntries();
+  const urlNodes = sitemapEntries.map(createUrlNode).join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urlNodes}\n</urlset>\n`;
+};
+
+// public 경로에 생성해 webpack 복사 단계에서 배포 산출물에 포함되도록 한다.
+const outputPath = resolve(__dirname, '../public/sitemap.xml');
+const sitemapXml = createSitemapXml();
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, sitemapXml, 'utf8');
+
+console.log(`Generated sitemap: ${outputPath}`);
+console.log(`Included URLs: ${STATIC_PATHS.length} (static only)`);

--- a/frontend/scripts/generate-sitemap.mjs
+++ b/frontend/scripts/generate-sitemap.mjs
@@ -6,7 +6,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 // 기본 도메인은 운영 주소를 사용하고, 필요하면 CI/스테이징에서 환경변수로 덮어쓴다.
-const SITE_URL = process.env.SITEMAP_SITE_URL || 'https://routie.me';
+const SITE_URL = (process.env.SITEMAP_SITE_URL || 'https://routie.me').replace(
+  /\/+$/,
+  '',
+);
 // 검색 인덱싱 대상인 공개 정적 라우트만 유지한다.
 const STATIC_PATHS = ['/', '/routie-spaces', '/version'];
 // 동적 라우트 사이트맵은 현재 비활성화 상태다.


### PR DESCRIPTION
## As-Is
- 랜딩 페이지 메타 정보가 제한적이라 검색/공유 노출 정보가 충분하지 않았습니다.
- `robots.txt`, `sitemap.xml`이 없어 검색엔진이 사이트 구조를 안정적으로 파악하기 어려웠습니다.
- sitemap 생성을 수동으로 하면 배포 시 최신 상태 보장이 어려웠습니다.
- CI 빌드가 `build:prod` 경로를 타지 않아 sitemap 자동 생성 훅이 보장되지 않았습니다.

## To-Be
- `public/index.html`
  - Google Search Console 인증 메타 태그 추가
  - `description`, `robots` 명시
  - Open Graph/Twitter Card 메타 보강
  - JSON-LD(`WebSite`) 구조화 데이터 추가
- `public/robots.txt` 추가
  - `Allow: /`
  - `Disallow: /auth/`
  - `Disallow: /manage-routie-spaces`
  - `Sitemap: https://routie.me/sitemap.xml`
- `scripts/generate-sitemap.mjs` 추가
  - 정적 공개 경로(`/, /routie-spaces, /version`) sitemap 자동 생성
  - `lastmod` 포함
  - 동적 확장용 주석(TODO) 추가, 현재는 정적만 생성
- `package.json`
  - `generate:sitemap` 추가
  - `prebuild:prod`에서 sitemap 자동 생성 연결
- `.github/workflows/ci.yml`
  - `npm run build` -> `npm run build:prod` 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
1. 현재 `sitemap.xml`은 정적 경로만 포함합니다.
  - 동적 경로는 추후 백엔드에서 공개 가능한 식별자/`updatedAt`을 받아 확장할 수 있도록 주석으로 가이드해두었습니다.
2. 사이트맵 제출을 위해 Google Search Console 인증 메타 태그를 추가했습니다.
  - 해당 인증은 프로덕션 도메인에 배포된 페이지에서만 유효하므로, 먼저 main 브랜치에 머지 후 배포가 필요합니다.
  - 배포 완료 후 Google Search Console에 서비스를 등록하고 sitemap을 제출하면 검색엔진 색인이 진행됩니다.



Closes #1087


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 자동 사이트맵 생성 기능 추가
  * robots.txt 추가로 크롤링 제어 제공
  * JSON-LD 구조화 데이터 추가

* **개선사항**
  * SEO 메타데이터(타이틀·설명·Open Graph·Twitter Card) 및 한국어 콘텐츠로 업데이트
  * 프로덕션 빌드가 최적화된 빌드 작업으로 전환됨

* **기타**
  * 린터/스타일 검사에서 특정 스크립트 경로를 무시하도록 구성 확장됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->