### PR TITLE
chore: 프론트 CD 필수 env 검증 키를 3개로 명시

### DIFF
--- a/.github/workflows/frontend-dev-cd.yml
+++ b/.github/workflows/frontend-dev-cd.yml
@@ -71,12 +71,15 @@ jobs:
       - name: Build
         run: npm run build:dev
 
-      - name: Verify env injection
+      - name: Verify required env injection
         run: |
-          if grep -R -n --include="*.js" "MISSING_ENV_VAR" dist; then
-            echo "Missing env injection in frontend build output"
-            exit 1
-          fi
+          REQUIRED_KEYS=("REACT_APP_API_URL" "REACT_APP_SENTRY_DSN" "REACT_APP_KAKAO_MAP_APPKEY")
+          for key in "${REQUIRED_KEYS[@]}"; do
+            if grep -R -n --include="*.js" "\"MISSING_ENV_VAR\".${key}" dist; then
+              echo "Missing required env injection: ${key}"
+              exit 1
+            fi
+          done
 
       # 5) AWS 인증 (Access Key 방식)
       - name: Configure AWS credentials (Access Key)

--- a/.github/workflows/frontend-prod-cd.yml
+++ b/.github/workflows/frontend-prod-cd.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Build
         run: npm run build:prod
 
-      - name: Verify env injection
+      - name: Verify required env injection
         run: |
-          if grep -R -n --include="*.js" "MISSING_ENV_VAR" dist; then
-            echo "Missing env injection in frontend build output"
-            exit 1
-          fi
+          REQUIRED_KEYS=("REACT_APP_API_URL" "REACT_APP_SENTRY_DSN" "REACT_APP_KAKAO_MAP_APPKEY")
+          for key in "${REQUIRED_KEYS[@]}"; do
+            if grep -R -n --include="*.js" "\"MISSING_ENV_VAR\".${key}" dist; then
+              echo "Missing required env injection: ${key}"
+              exit 1
+            fi
+          done
 
       # 5) AWS 인증 (Access Key 방식)
       - name: Configure AWS credentials (Access Key)


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
- CD 검증 단계에서 MISSING_ENV_VAR를 광범위하게 검사해, DEV에서 비필수인 값(예: GA4) 누락까지 배포 실패로 처리되는 문제가 있었습니다.

## To-Be
<!-- 변경 사항 -->
- frontend-dev-cd.yml, frontend-prod-cd.yml의 env 검증을 필수 키 3개만 확인하도록 변경했습니다.
  - REACT_APP_API_URL
  - REACT_APP_SENTRY_DSN
  - REACT_APP_KAKAO_MAP_APPKEY
- 위 3개 키에 대해서만 MISSING_ENV_VAR 패턴이 발견되면 배포를 실패시키도록 조정했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description


<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->
