### PR TITLE
feat: 햄버거 메뉴 닫기 동작 개선

### DIFF
--- a/frontend/e2e/route.spec.ts
+++ b/frontend/e2e/route.spec.ts
@@ -38,7 +38,7 @@ test.describe('동선탭 - 동선 내 장소 관리', () => {
   }) => {
     await page.getByText('동선', { exact: true }).click();
 
-    const menuButton = page.getByLabel('메뉴 열기').first();
+    const menuButton = page.getByLabel('메뉴 열기', { exact: true }).first();
     await expect(menuButton).toBeVisible();
     await menuButton.click();
 
@@ -52,7 +52,7 @@ test.describe('동선탭 - 동선 내 장소 관리', () => {
 
     await expect(page.getByText('스타벅스 강남점')).toBeVisible();
 
-    const menuButton = page.getByLabel('메뉴 열기').first();
+    const menuButton = page.getByLabel('메뉴 열기', { exact: true }).first();
     await menuButton.click();
     await page.getByLabel('동선에서 장소 삭제').click();
 

--- a/frontend/src/domains/auth/components/UserMenuButton/UserMenuButton.styles.ts
+++ b/frontend/src/domains/auth/components/UserMenuButton/UserMenuButton.styles.ts
@@ -2,6 +2,25 @@ import { css } from '@emotion/react';
 
 import theme from '@/styles/theme';
 
+const UserMenuTriggerButtonStyle = css`
+  display: flex;
+
+  padding: 0;
+  border: none;
+  border-radius: ${theme.radius.sm};
+
+  background: transparent;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 0.2rem solid ${theme.colors.blue[450]};
+    outline-offset: 0.2rem;
+  }
+`;
+
 const UserMenuIconStyle = css`
   cursor: pointer;
 
@@ -29,6 +48,7 @@ const UserMenuButtonAbsoluteStyle = css`
 `;
 
 export {
+  UserMenuTriggerButtonStyle,
   UserMenuIconStyle,
   UserMenuButtonWrapperStyle,
   UserMenuButtonAbsoluteStyle,

--- a/frontend/src/domains/auth/components/UserMenuButton/UserMenuButton.tsx
+++ b/frontend/src/domains/auth/components/UserMenuButton/UserMenuButton.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { Suspense, useState } from 'react';
+import { Suspense } from 'react';
 
 import Button from '@/@common/components/Button/Button';
 import ErrorBoundary from '@/@common/components/ErrorBoundary/ErrorBoundary';
@@ -9,9 +9,11 @@ import Text from '@/@common/components/Text/Text';
 import { logout } from '@/@common/utils/logout';
 import UserMenu from '@/domains/auth/components/UserMenu/UserMenu';
 import { UserMenuStyle } from '@/domains/auth/components/UserMenu/UserMenu.styles';
+import { useUserMenuVisibility } from '@/domains/auth/hooks/useUserMenuVisibility';
 
 import {
   UserMenuIconStyle,
+  UserMenuTriggerButtonStyle,
   UserMenuButtonWrapperStyle,
   UserMenuButtonAbsoluteStyle,
 } from './UserMenuButton.styles';
@@ -22,14 +24,19 @@ const UserMenuButton = ({
   onClick,
   positioning = 'absolute',
 }: UserMenuButtonProps) => {
-  const [isUserInfoOpen, setIsUserInfoOpen] = useState(false);
+  const {
+    isUserMenuOpen,
+    userMenuRef,
+    userMenuTriggerButtonRef,
+    toggleUserMenu,
+  } = useUserMenuVisibility();
   const handleLogout = () => logout();
 
   const handleProfileClick = () => {
     if (onClick) {
       onClick();
     } else {
-      setIsUserInfoOpen((prev) => !prev);
+      toggleUserMenu();
     }
   };
 
@@ -39,14 +46,20 @@ const UserMenuButton = ({
       : UserMenuButtonWrapperStyle;
 
   return (
-    <div css={wrapperStyle}>
-      <Icon
-        name="menu"
-        size={40}
-        css={UserMenuIconStyle}
+    <div css={wrapperStyle} ref={userMenuRef}>
+      <button
+        type="button"
+        ref={userMenuTriggerButtonRef}
+        css={UserMenuTriggerButtonStyle}
         onClick={handleProfileClick}
-      />
-      {isUserInfoOpen && (
+        aria-label="사용자 메뉴 열기"
+        aria-haspopup="menu"
+        aria-controls="userMenu"
+        aria-expanded={isUserMenuOpen}
+      >
+        <Icon name="menu" size={40} css={UserMenuIconStyle} />
+      </button>
+      {isUserMenuOpen && (
         <ErrorBoundary
           fallbackRender={() => (
             <div css={UserMenuStyle}>

--- a/frontend/src/domains/auth/components/UserMenuButton/__tests__/UserMenuButton.test.tsx
+++ b/frontend/src/domains/auth/components/UserMenuButton/__tests__/UserMenuButton.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import UserMenuButton from '../UserMenuButton';
+
+vi.mock('@/@common/utils/logout', () => ({
+  logout: vi.fn(),
+}));
+
+vi.mock('@/domains/auth/components/UserMenu/UserMenu', () => ({
+  default: ({ onClick }: { onClick: () => void }) => (
+    <div id="userMenu" data-testid="user-menu">
+      <button type="button">내 동선 목록</button>
+      <button type="button" onClick={onClick}>
+        로그아웃
+      </button>
+    </div>
+  ),
+}));
+
+const openUserMenu = async () => {
+  const triggerButton = screen.getByRole('button', { name: '사용자 메뉴 열기' });
+
+  await userEvent.setup().click(triggerButton);
+
+  return triggerButton;
+};
+
+describe('UserMenuButton', () => {
+  it('초기 상태에서 메뉴는 닫혀 있고 접근성 속성을 노출한다', () => {
+    render(<UserMenuButton positioning="relative" />);
+
+    const triggerButton = screen.getByRole('button', {
+      name: '사용자 메뉴 열기',
+    });
+
+    expect(triggerButton).toHaveAttribute('aria-haspopup', 'menu');
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('user-menu')).not.toBeInTheDocument();
+  });
+
+  it('트리거 버튼 클릭 시 메뉴를 열고 aria-expanded를 갱신한다', async () => {
+    render(<UserMenuButton positioning="relative" />);
+
+    const triggerButton = await openUserMenu();
+
+    expect(screen.getByTestId('user-menu')).toBeInTheDocument();
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('메뉴 내부 클릭만으로는 메뉴가 닫히지 않는다', async () => {
+    render(<UserMenuButton positioning="relative" />);
+
+    await openUserMenu();
+
+    await userEvent.setup().click(screen.getByRole('button', { name: '내 동선 목록' }));
+
+    expect(screen.getByTestId('user-menu')).toBeInTheDocument();
+  });
+
+  it('메뉴 외부를 클릭하면 메뉴가 닫히고 aria-expanded를 false로 되돌린다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <UserMenuButton positioning="relative" />
+        <button type="button">외부 버튼</button>
+      </div>,
+    );
+
+    const triggerButton = screen.getByRole('button', {
+      name: '사용자 메뉴 열기',
+    });
+
+    await user.click(triggerButton);
+    await user.click(screen.getByRole('button', { name: '외부 버튼' }));
+
+    expect(screen.queryByTestId('user-menu')).not.toBeInTheDocument();
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('Escape 입력 시 메뉴가 닫히고 트리거 버튼으로 포커스가 돌아간다', async () => {
+    const user = userEvent.setup();
+
+    render(<UserMenuButton positioning="relative" />);
+
+    const triggerButton = screen.getByRole('button', {
+      name: '사용자 메뉴 열기',
+    });
+
+    await user.click(triggerButton);
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByTestId('user-menu')).not.toBeInTheDocument();
+    expect(triggerButton).toHaveFocus();
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('Escape 이외의 키 입력으로는 메뉴가 닫히지 않는다', async () => {
+    const user = userEvent.setup();
+
+    render(<UserMenuButton positioning="relative" />);
+
+    await openUserMenu();
+    await user.keyboard('a');
+
+    expect(screen.getByTestId('user-menu')).toBeInTheDocument();
+  });
+
+  it('열리지 않은 상태에서 외부 클릭이나 Escape 입력이 발생해도 메뉴를 다시 열지 않는다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <UserMenuButton positioning="relative" />
+        <button type="button">외부 버튼</button>
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button', { name: '외부 버튼' }));
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByTestId('user-menu')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '사용자 메뉴 열기' }),
+    ).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/frontend/src/domains/auth/hooks/useUserMenuVisibility.ts
+++ b/frontend/src/domains/auth/hooks/useUserMenuVisibility.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useUserMenuVisibility = () => {
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const userMenuRef = useRef<HTMLDivElement>(null);
+  const userMenuTriggerButtonRef = useRef<HTMLButtonElement>(null);
+
+  const closeUserMenu = (shouldRestoreFocus = false) => {
+    setIsUserMenuOpen(false);
+
+    if (shouldRestoreFocus) {
+      userMenuTriggerButtonRef.current?.focus();
+    }
+  };
+
+  useEffect(() => {
+    if (!isUserMenuOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        userMenuRef.current &&
+        !userMenuRef.current.contains(event.target as Node)
+      ) {
+        closeUserMenu();
+      }
+    };
+
+    const handleEscapeKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeUserMenu(true);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscapeKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscapeKeyDown);
+    };
+  }, [isUserMenuOpen]);
+
+  const toggleUserMenu = () => {
+    setIsUserMenuOpen((prev) => !prev);
+  };
+
+  return {
+    isUserMenuOpen,
+    userMenuRef,
+    userMenuTriggerButtonRef,
+    toggleUserMenu,
+    closeUserMenu,
+  };
+};
+
+export { useUserMenuVisibility };


### PR DESCRIPTION
close #1096

## As-Is
<!-- 문제 상황 정의 -->
  - 우측 상단 햄버거 버튼 클릭 시 사용자 메뉴가 열림
  - 메뉴가 열린 상태에서 외부 영역을 클릭해도 닫히지 않음
  - `Escape` 입력으로도 닫히지 않아, 버튼을 다시 눌러야만 종료 가능
  - 일반적인 드롭다운 종료 패턴과 달라 마우스/키보드 사용자 모두 불편함이 있었음

## To-Be
<!-- 변경 사항 -->
  - 햄버거 메뉴 외부 클릭 시 메뉴가 닫히도록 개선
  - `Escape` 입력 시 메뉴가 닫히도록 개선
  - 사용자 메뉴 열림/닫힘 로직을 `useUserMenuVisibility` 훅으로 분리
  - 메뉴 트리거를 `button`으로 감싸고 `aria-expanded`, `aria-haspopup`, `aria-controls` 속성 추가
  - `Escape`로 닫힌 경우 트리거 버튼으로 포커스가 돌아가도록 처리
  - 사용자 메뉴 닫기 동작 관련 테스트 추가

## Check List
  - [x] 테스트가 전부 통과되었나요?
  - [x] 모든 commit이 push 되었나요?
  - [x] merge할 branch를 확인했나요?
  - [x] Assignee를 지정했나요?
  - [x] Label을 지정했나요?

## Test Screenshot


## (Optional) Additional Description
  - 외부 클릭 닫기와 `Escape` 닫기를 사용자 메뉴 전용 훅으로 분리해, 이후 유사한 오버레이 UI에도 재사용할 수 있도록 정리했습니다.
  - 포커스 복귀는 모든 닫힘 상황이 아니라 `Escape`로 닫는 경우에만 적용했습니다. 외부 클릭 시에는 사용자가 실제로 클릭한 요소의 포커스를 유지하는 쪽이 자연스럽다고 판단했습니다.
  - 사용자 메뉴 테스트를 추가해 아래 케이스를 검증했습니다.
    - 초기 접근성 속성 노출
    - 트리거 클릭 시 메뉴 열림
    - 메뉴 내부 클릭 시 유지
    - 외부 클릭 시 닫힘
    - `Escape` 입력 시 닫힘 및 포커스 복귀
    - `Escape` 외 키 입력 무시
    - 닫힌 상태에서 외부 클릭/`Escape` 입력 무영향

<!-- merge 시 이슈를 자동으로 닫고자 할 때 사용
Closes #{이슈번호}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사용자 메뉴에 키보드 네비게이션 지원 추가 (Escape 키로 메뉴 닫기)
  * 메뉴 외부 영역 클릭 시 자동 닫힘
  * 접근성 개선으로 스크린 리더 호환성 향상

* **테스트**
  * 사용자 메뉴 상호작용에 대한 포괄적인 테스트 스위트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->