### PR TITLE
feat: 채팅 UI 및 로직 구현

### DIFF
--- a/frontend/src/@common/components/IconSvg/allIcons.ts
+++ b/frontend/src/@common/components/IconSvg/allIcons.ts
@@ -1,6 +1,7 @@
 import allSelect from '@/assets/icons/all-select.svg';
 import allUnselect from '@/assets/icons/all-unselect.svg';
 import arrow from '@/assets/icons/arrow.svg';
+import chatTab from '@/assets/icons/chat-tab.svg';
 import checkHome from '@/assets/icons/check-home.svg';
 import check from '@/assets/icons/check.svg';
 import clockHome from '@/assets/icons/clock-home.svg';
@@ -36,6 +37,7 @@ import mascot from '@/assets/images/routie-mascot.png';
 
 const allIcons = {
   allSelect,
+  chatTab,
   allUnselect,
   arrow,
   check,

--- a/frontend/src/assets/icons/chat-tab.svg
+++ b/frontend/src/assets/icons/chat-tab.svg
@@ -1,0 +1,6 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M15 4C9.477 4 5 8.03 5 13c0 2.56 1.12 4.87 2.94 6.51L7 23l3.88-1.55A10.9 10.9 0 0 0 15 22c5.523 0 10-4.03 10-9s-4.477-9-10-9Z" stroke="#0048FF" stroke-width="1.8" stroke-linejoin="round"/>
+  <circle cx="11" cy="13" r="1.2" fill="#0048FF"/>
+  <circle cx="15" cy="13" r="1.2" fill="#0048FF"/>
+  <circle cx="19" cy="13" r="1.2" fill="#0048FF"/>
+</svg>

--- a/frontend/src/domains/chat/hooks/useChat.ts
+++ b/frontend/src/domains/chat/hooks/useChat.ts
@@ -17,33 +17,41 @@ const useChat = ({ routieSpaceUuid, accessToken, myNickname }: UseChatParams) =>
   const [messages, setMessages] = useState<ChatMessageType[]>([]);
   const [isConnected, setIsConnected] = useState(false);
 
-  const handleMessage = useCallback((data: ChatIncomingMessageType) => {
-    if (data.type === 'CHAT_ACK') {
-      setMessages((prev) =>
-        prev.map((msg) =>
-          msg.tempId === data.tempId
-            ? { ...msg, messageId: data.messageId, timestamp: data.timestamp, status: 'sent', tempId: undefined }
-            : msg,
-        ),
-      );
-      return;
-    }
+  const handleMessage = useCallback(
+    (data: ChatIncomingMessageType) => {
+      if (data.type === 'CHAT_ACK') {
+        setMessages((prev) =>
+          prev.map((msg) =>
+            msg.tempId === data.tempId
+              ? { ...msg, messageId: data.messageId, timestamp: data.timestamp, status: 'sent', tempId: undefined }
+              : msg,
+          ),
+        );
+        return;
+      }
 
-    if (data.type === 'CHAT') {
-      setMessages((prev) => [
-        ...prev,
-        {
-          messageId: data.messageId,
-          senderId: data.senderId,
-          senderName: data.senderName,
-          content: data.content,
-          timestamp: data.timestamp,
-          status: 'sent',
-          isMine: false,
-        },
-      ]);
-    }
-  }, []);
+      if (data.type === 'CHAT') {
+        setMessages((prev) => {
+          const alreadyExists = prev.some((msg) => msg.messageId === data.messageId);
+          if (alreadyExists) return prev;
+
+          return [
+            ...prev,
+            {
+              messageId: data.messageId,
+              senderId: data.senderId,
+              senderName: data.senderName,
+              content: data.content,
+              timestamp: data.timestamp,
+              status: 'sent',
+              isMine: data.senderId === myNickname,
+            },
+          ];
+        });
+      }
+    },
+    [myNickname],
+  );
 
   const { send } = useWebSocket<ChatIncomingMessageType>({
     url: WS_CHAT_URL,
@@ -78,7 +86,10 @@ const useChat = ({ routieSpaceUuid, accessToken, myNickname }: UseChatParams) =>
         return;
       }
 
-      send({ type: 'CHAT', tempId, content });
+      const isSent = send({ type: 'CHAT', tempId, content });
+      if (!isSent) {
+        setMessages((prev) => prev.filter((msg) => msg.tempId !== tempId));
+      }
     },
     [send, myNickname, isConnected],
   );

--- a/frontend/src/domains/chat/hooks/useChat.ts
+++ b/frontend/src/domains/chat/hooks/useChat.ts
@@ -32,7 +32,9 @@ const useChat = ({ routieSpaceUuid, accessToken, myNickname }: UseChatParams) =>
 
       if (data.type === 'CHAT') {
         setMessages((prev) => {
-          const alreadyExists = prev.some((msg) => msg.messageId === data.messageId);
+          const alreadyExists = prev.some(
+            (msg) => msg.messageId === data.messageId || msg.tempId === data.messageId,
+          );
           if (alreadyExists) return prev;
 
           return [

--- a/frontend/src/domains/chat/hooks/useChat.ts
+++ b/frontend/src/domains/chat/hooks/useChat.ts
@@ -1,0 +1,89 @@
+import { useCallback, useState } from 'react';
+
+import { useWebSocket } from '@/libs/websocket/hooks/useWebSocket';
+
+import type { ChatIncomingMessageType } from '../types/api.types';
+import type { ChatMessageType } from '../types/chat.types';
+
+const WS_CHAT_URL = `${process.env.REACT_APP_API_URL?.replace(/^http/, 'ws') ?? 'ws://localhost:8080'}/ws/chat/v1`;
+
+interface UseChatParams {
+  routieSpaceUuid: string;
+  accessToken: string;
+  myNickname: string;
+}
+
+const useChat = ({ routieSpaceUuid, accessToken, myNickname }: UseChatParams) => {
+  const [messages, setMessages] = useState<ChatMessageType[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+
+  const handleMessage = useCallback((data: ChatIncomingMessageType) => {
+    if (data.type === 'CHAT_ACK') {
+      setMessages((prev) =>
+        prev.map((msg) =>
+          msg.tempId === data.tempId
+            ? { ...msg, messageId: data.messageId, timestamp: data.timestamp, status: 'sent', tempId: undefined }
+            : msg,
+        ),
+      );
+      return;
+    }
+
+    if (data.type === 'CHAT') {
+      setMessages((prev) => [
+        ...prev,
+        {
+          messageId: data.messageId,
+          senderId: data.senderId,
+          senderName: data.senderName,
+          content: data.content,
+          timestamp: data.timestamp,
+          status: 'sent',
+          isMine: false,
+        },
+      ]);
+    }
+  }, []);
+
+  const { send } = useWebSocket<ChatIncomingMessageType>({
+    url: WS_CHAT_URL,
+    token: accessToken,
+    subscribeDestination: `/topic/chat/${routieSpaceUuid}`,
+    publishDestination: `/app/chat/${routieSpaceUuid}`,
+    onMessage: handleMessage,
+    onConnect: useCallback(() => setIsConnected(true), []),
+    onDisconnect: useCallback(() => setIsConnected(false), []),
+  });
+
+  const sendMessage = useCallback(
+    (content: string) => {
+      const tempId = crypto.randomUUID();
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          messageId: tempId,
+          tempId,
+          senderId: myNickname,
+          senderName: myNickname,
+          content,
+          timestamp: new Date().toISOString(),
+          status: 'pending',
+          isMine: true,
+        },
+      ]);
+
+      if (!isConnected) {
+        setMessages((prev) => prev.filter((msg) => msg.tempId !== tempId));
+        return;
+      }
+
+      send({ type: 'CHAT', tempId, content });
+    },
+    [send, myNickname, isConnected],
+  );
+
+  return { messages, sendMessage };
+};
+
+export { useChat };

--- a/frontend/src/domains/chat/types/api.types.ts
+++ b/frontend/src/domains/chat/types/api.types.ts
@@ -1,0 +1,30 @@
+interface ChatSendRequest {
+  type: 'CHAT';
+  tempId: string;
+  content: string;
+}
+
+interface ChatAckResponse {
+  type: 'CHAT_ACK';
+  tempId: string;
+  messageId: string;
+  timestamp: string;
+}
+
+interface ChatMessageResponse {
+  type: 'CHAT';
+  messageId: string;
+  senderId: string;
+  senderName: string;
+  content: string;
+  timestamp: string;
+}
+
+type ChatIncomingMessageType = ChatAckResponse | ChatMessageResponse;
+
+export type {
+  ChatSendRequest,
+  ChatAckResponse,
+  ChatMessageResponse,
+  ChatIncomingMessageType,
+};

--- a/frontend/src/domains/chat/types/chat.types.ts
+++ b/frontend/src/domains/chat/types/chat.types.ts
@@ -1,0 +1,14 @@
+type ChatMessageStatus = 'pending' | 'sent';
+
+interface ChatMessageType {
+  messageId: string;
+  tempId?: string;
+  senderId: string;
+  senderName: string;
+  content: string;
+  timestamp: string;
+  status: ChatMessageStatus;
+  isMine: boolean;
+}
+
+export type { ChatMessageType, ChatMessageStatus };

--- a/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
+++ b/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router';
 
-import FeedbackWidget from '@/@common/components/FeedbackWidget/FeedbackWidget';
 import { useModal } from '@/@common/contexts/ModalContext';
 import { useToastContext } from '@/@common/contexts/useToastContext';
 import { useToggle } from '@/@common/hooks/useToggle';
@@ -15,6 +14,7 @@ import { usePlaceStream } from '@/domains/places/hooks/usePlaceStream';
 import { useRoutieStream } from '@/domains/routie/hooks/useRoutieStream';
 import { useRoutieSpaceStream } from '@/domains/routieSpace/hooks/useRoutieSpaceStream';
 import { useSuspenseRoutieSpaceQuery } from '@/domains/routieSpace/queries/useRoutieSpaceQuery';
+import ChatView from '@/pages/RoutieSpace/components/ChatView/ChatView';
 import Sidebar from '@/pages/RoutieSpace/components/Sidebar/Sidebar';
 
 import { RoutieSpaceContainerStyle } from './RoutieSpace.styles';
@@ -29,7 +29,7 @@ const RoutieSpace = () => {
 
   const { openModal } = useModal();
   const { showToast } = useToastContext();
-  const { error } = useUserQuery();
+  const { error, data: user } = useUserQuery();
   useSuspenseRoutieSpaceQuery();
   const accessToken = getAccessToken();
   const { isOpen: isSidebarOpen, handleToggle: handleSidebarToggle } =
@@ -68,7 +68,12 @@ const RoutieSpace = () => {
         {accessToken && <UserMenuButton />}
         <Sidebar isOpen={isSidebarOpen} onToggle={handleSidebarToggle} />
       </div>
-      <FeedbackWidget />
+      {accessToken && (
+        <ChatView
+          accessToken={accessToken}
+          myNickname={user?.nickname ?? ''}
+        />
+      )}
     </HashtagFilterProvider>
   );
 };

--- a/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
+++ b/frontend/src/pages/RoutieSpace/RoutieSpace.tsx
@@ -68,10 +68,10 @@ const RoutieSpace = () => {
         {accessToken && <UserMenuButton />}
         <Sidebar isOpen={isSidebarOpen} onToggle={handleSidebarToggle} />
       </div>
-      {accessToken && (
+      {accessToken && user?.nickname && (
         <ChatView
           accessToken={accessToken}
-          myNickname={user?.nickname ?? ''}
+          myNickname={user.nickname}
         />
       )}
     </HashtagFilterProvider>

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatInput.styles.ts
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatInput.styles.ts
@@ -49,9 +49,9 @@ const sendButtonStyle = (disabled: boolean) => css`
   align-items: center;
   justify-content: center;
 
-  aspect-ratio: 1;
-  width: 2.2rem;
-  height: 3.2rem;
+
+  width: 2.8rem;
+  height: 2.8rem;
   border: none;
   border-radius: 50%;
 

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatInput.styles.ts
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatInput.styles.ts
@@ -1,0 +1,71 @@
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const inputContainerStyle = css`
+  display: flex;
+  gap: 0.8rem;
+  align-items: flex-end;
+
+  padding: 1rem 1.2rem;
+  border-top: 1px solid ${theme.colors.gray[25]};
+
+  background-color: ${theme.colors.white};
+`;
+
+const textareaStyle = css`
+  resize: none;
+
+  overflow-y: hidden;
+  flex: 1;
+
+  padding: 0.7rem 0.8rem;
+  border: 1.5px solid ${theme.colors.gray[25]};
+  border-radius: ${theme.radius.sm};
+
+  font-family: inherit;
+  font-size: ${theme.font.size.caption};
+  line-height: 1.5;
+  color: ${theme.colors.gray[300]};
+
+  background-color: ${theme.colors.white};
+  outline: none;
+
+  &::placeholder {
+    color: ${theme.colors.gray[100]};
+  }
+
+  &:focus {
+    border-color: ${theme.colors.blue[300]};
+    border-width: 2px;
+  }
+`;
+
+const sendButtonStyle = (disabled: boolean) => css`
+  cursor: ${disabled ? 'default' : 'pointer'};
+
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+
+  aspect-ratio: 1;
+  width: 2.2rem;
+  height: 3.2rem;
+  border: none;
+  border-radius: 50%;
+
+  background-color: ${disabled
+    ? theme.colors.gray[25]
+    : theme.colors.blue[450]};
+
+  transition: background-color 0.15s;
+`;
+
+const sendIconStyle = css`
+  width: 1.6rem;
+  height: 1.6rem;
+  fill: ${theme.colors.white};
+`;
+
+export { inputContainerStyle, textareaStyle, sendButtonStyle, sendIconStyle };

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatInput.tsx
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatInput.tsx
@@ -1,0 +1,54 @@
+/** @jsxImportSource @emotion/react */
+import { useState } from 'react';
+
+import {
+  inputContainerStyle,
+  sendButtonStyle,
+  sendIconStyle,
+  textareaStyle,
+} from './ChatInput.styles';
+
+interface ChatInputProps {
+  onSend: (content: string) => void;
+}
+
+const ChatInput = ({ onSend }: ChatInputProps) => {
+  const [value, setValue] = useState('');
+
+  const handleSend = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+
+    onSend(trimmed);
+    setValue('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const isEmpty = value.trim().length === 0;
+
+  return (
+    <div css={inputContainerStyle}>
+      <textarea
+        css={textareaStyle}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="메시지를 입력하세요"
+        rows={1}
+      />
+      <button css={sendButtonStyle(isEmpty)} onClick={handleSend} disabled={isEmpty}>
+        <svg css={sendIconStyle} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M2 21L23 12 2 3v7l15 2-15 2z" />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default ChatInput;

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatInput.tsx
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatInput.tsx
@@ -42,7 +42,7 @@ const ChatInput = ({ onSend }: ChatInputProps) => {
         placeholder="메시지를 입력하세요"
         rows={1}
       />
-      <button css={sendButtonStyle(isEmpty)} onClick={handleSend} disabled={isEmpty}>
+      <button type="button" aria-label="메시지 전송" css={sendButtonStyle(isEmpty)} onClick={handleSend} disabled={isEmpty}>
         <svg css={sendIconStyle} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path d="M2 21L23 12 2 3v7l15 2-15 2z" />
         </svg>

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatMessage.styles.ts
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatMessage.styles.ts
@@ -1,0 +1,53 @@
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const messageRowStyle = (isMine: boolean) => css`
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  align-items: ${isMine ? 'flex-end' : 'flex-start'};
+`;
+
+const senderNameStyle = css`
+  padding: 0 0.4rem;
+  font-size: ${theme.font.size.label};
+  color: ${theme.colors.gray[200]};
+`;
+
+const bubbleWrapStyle = (isMine: boolean) => css`
+  display: flex;
+  flex-direction: ${isMine ? 'row-reverse' : 'row'};
+  gap: 0.5rem;
+  align-items: flex-end;
+`;
+
+const bubbleStyle = (isMine: boolean) => css`
+  max-width: 26rem;
+  padding: 0.8rem 1.2rem;
+  border-radius: ${isMine
+    ? `${theme.radius.md} 4px ${theme.radius.md} ${theme.radius.md}`
+    : `4px ${theme.radius.md} ${theme.radius.md} ${theme.radius.md}`};
+
+  font-size: ${theme.font.size.caption};
+  line-height: 1.5;
+  color: ${isMine ? theme.colors.white : theme.colors.gray[300]};
+  overflow-wrap: break-word;
+
+  background-color: ${isMine ? theme.colors.blue[450] : theme.colors.gray[50]};
+`;
+
+const timestampStyle = css`
+  padding-bottom: 0.2rem;
+  font-size: ${theme.font.size.description};
+  color: ${theme.colors.gray[100]};
+  white-space: nowrap;
+`;
+
+export {
+  messageRowStyle,
+  senderNameStyle,
+  bubbleWrapStyle,
+  bubbleStyle,
+  timestampStyle,
+};

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatMessage.tsx
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatMessage.tsx
@@ -1,0 +1,37 @@
+/** @jsxImportSource @emotion/react */
+import {
+  bubbleStyle,
+  bubbleWrapStyle,
+  messageRowStyle,
+  senderNameStyle,
+  timestampStyle,
+} from './ChatMessage.styles';
+
+import type { ChatMessageProps } from './ChatMessage.types';
+
+const formatTime = (isoString: string) => {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' });
+};
+
+const ChatMessage = ({
+  isMine,
+  senderName,
+  content,
+  timestamp,
+  status,
+}: ChatMessageProps) => {
+  return (
+    <div css={messageRowStyle(isMine)}>
+      {!isMine && <span css={senderNameStyle}>{senderName}</span>}
+      <div css={bubbleWrapStyle(isMine)}>
+        <div css={bubbleStyle(isMine)}>{content}</div>
+        <span css={timestampStyle}>
+          {status === 'pending' ? '...' : formatTime(timestamp)}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default ChatMessage;

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatMessage.types.ts
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatMessage.types.ts
@@ -1,0 +1,5 @@
+import type { ChatMessageType } from '@/domains/chat/types/chat.types';
+
+type ChatMessageProps = ChatMessageType;
+
+export type { ChatMessageProps };

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.styles.ts
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.styles.ts
@@ -1,0 +1,127 @@
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const chatIconButtonStyle = css`
+  cursor: pointer;
+
+  position: fixed;
+  z-index: 100;
+  right: 3rem;
+  bottom: 3rem;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 0.8rem;
+  border-radius: 50%;
+
+  background-color: ${theme.colors.white};
+  box-shadow: 0 0.4rem 1.2rem rgb(0 0 0 / 20%);
+
+  &:hover {
+    transform: scale(1.08);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+`;
+
+const chatPanelStyle = (isOpen: boolean) => css`
+  pointer-events: ${isOpen ? 'auto' : 'none'};
+
+  position: fixed;
+  z-index: 99;
+  right: 3rem;
+  bottom: 3rem;
+  transform: translateY(${isOpen ? '0' : '1rem'});
+
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  width: 34rem;
+  height: 50rem;
+  border: 0.5px solid ${theme.colors.gray[100]};
+  border-radius: ${theme.radius.sm};
+
+  opacity: ${isOpen ? 1 : 0};
+  background-color: ${theme.colors.white};
+  box-shadow: 2px 4px 12px 0 rgb(0 0 0 / 20%);
+
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+`;
+
+const chatPanelHeaderStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 1.2rem 1.6rem;
+  border-bottom: 1px solid ${theme.colors.gray[25]};
+  border-radius: 0;
+
+  background-color: ${theme.colors.blue[450]};
+`;
+
+const chatPanelHeaderTitleStyle = css`
+  font-size: ${theme.font.size.body};
+  font-weight: ${theme.font.weight.semibold};
+  color: ${theme.colors.white};
+`;
+
+const chatPanelCloseButtonStyle = css`
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 1rem;
+  height: 2.4rem;
+  border: none;
+  border-radius: 4px;
+
+  font-size: ${theme.font.size.body};
+  color: ${theme.colors.white};
+
+  background-color: transparent;
+
+  &:hover {
+    background-color: rgb(255 255 255 / 20%);
+  }
+`;
+
+const messageListStyle = css`
+  overflow-y: auto;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 1.2rem;
+
+  padding: 1.6rem;
+`;
+
+const emptyMessageStyle = css`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+
+  font-size: ${theme.font.size.caption};
+  color: ${theme.colors.gray[100]};
+`;
+
+export {
+  chatIconButtonStyle,
+  chatPanelStyle,
+  chatPanelHeaderStyle,
+  chatPanelHeaderTitleStyle,
+  chatPanelCloseButtonStyle,
+  messageListStyle,
+  emptyMessageStyle,
+};

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.styles.ts
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.styles.ts
@@ -15,6 +15,7 @@ const chatIconButtonStyle = css`
   justify-content: center;
 
   padding: 0.8rem;
+  border: none;
   border-radius: 50%;
 
   background-color: ${theme.colors.white};

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
@@ -1,0 +1,74 @@
+/** @jsxImportSource @emotion/react */
+import { useEffect, useRef, useState } from 'react';
+
+import Icon from '@/@common/components/IconSvg/Icon';
+import { useChat } from '@/domains/chat/hooks/useChat';
+import { getRoutieSpaceUuid } from '@/domains/utils/routieSpaceUuid';
+
+import ChatInput from './ChatInput';
+import ChatMessage from './ChatMessage';
+import {
+  chatIconButtonStyle,
+  chatPanelCloseButtonStyle,
+  chatPanelHeaderStyle,
+  chatPanelHeaderTitleStyle,
+  chatPanelStyle,
+  emptyMessageStyle,
+  messageListStyle,
+} from './ChatView.styles';
+
+import type { ChatViewProps } from './ChatView.types';
+
+const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const routieSpaceUuid = getRoutieSpaceUuid() ?? '';
+  const messageListRef = useRef<HTMLDivElement>(null);
+
+  const { messages, sendMessage } = useChat({
+    routieSpaceUuid,
+    accessToken,
+    myNickname,
+  });
+
+  useEffect(() => {
+    if (messageListRef.current) {
+      messageListRef.current.scrollTop = messageListRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  return (
+    <>
+      <div css={chatPanelStyle(isOpen)}>
+        <div css={chatPanelHeaderStyle}>
+          <span css={chatPanelHeaderTitleStyle}>채팅</span>
+          <button
+            css={chatPanelCloseButtonStyle}
+            onClick={() => setIsOpen(false)}
+          >
+            ✕
+          </button>
+        </div>
+        <div ref={messageListRef} css={messageListStyle}>
+          {messages.length === 0 ? (
+            <div css={emptyMessageStyle}>첫 메시지를 보내보세요!</div>
+          ) : (
+            messages.map((msg) => <ChatMessage key={msg.messageId} {...msg} />)
+          )}
+        </div>
+        ㅁ
+        <ChatInput onSend={sendMessage} />
+      </div>
+
+      <div
+        css={chatIconButtonStyle}
+        role="button"
+        tabIndex={0}
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        <Icon name="chatTab" size={36} />
+      </div>
+    </>
+  );
+};
+
+export default ChatView;

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
@@ -58,14 +58,16 @@ const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
         <ChatInput onSend={sendMessage} />
       </div>
 
-      <div
-        css={chatIconButtonStyle}
-        role="button"
-        tabIndex={0}
-        onClick={() => setIsOpen((prev) => !prev)}
-      >
-        <Icon name="chatTab" size={36} />
-      </div>
+      {!isOpen && (
+        <div
+          css={chatIconButtonStyle}
+          role="button"
+          tabIndex={0}
+          onClick={() => setIsOpen(true)}
+        >
+          <Icon name="chatTab" size={36} />
+        </div>
+      )}
     </>
   );
 };

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
@@ -55,7 +55,6 @@ const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
             messages.map((msg) => <ChatMessage key={msg.messageId} {...msg} />)
           )}
         </div>
-        ㅁ
         <ChatInput onSend={sendMessage} />
       </div>
 

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
@@ -17,15 +17,18 @@ import {
   messageListStyle,
 } from './ChatView.styles';
 
-import type { ChatViewProps } from './ChatView.types';
+import type { ChatViewProps, ChatViewInnerProps } from './ChatView.types';
 
-const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
+const ChatViewInner = ({
+  routieSpaceUuid,
+  accessToken,
+  myNickname,
+}: ChatViewInnerProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const routieSpaceUuid = getRoutieSpaceUuid();
   const messageListRef = useRef<HTMLDivElement>(null);
 
   const { messages, sendMessage } = useChat({
-    routieSpaceUuid: routieSpaceUuid ?? '',
+    routieSpaceUuid,
     accessToken,
     myNickname,
   });
@@ -35,8 +38,6 @@ const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
       messageListRef.current.scrollTop = messageListRef.current.scrollHeight;
     }
   }, [messages]);
-
-  if (!routieSpaceUuid) return null;
 
   return (
     <>
@@ -72,6 +73,20 @@ const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
         </button>
       )}
     </>
+  );
+};
+
+const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
+  const routieSpaceUuid = getRoutieSpaceUuid();
+
+  if (!routieSpaceUuid) return null;
+
+  return (
+    <ChatViewInner
+      routieSpaceUuid={routieSpaceUuid}
+      accessToken={accessToken}
+      myNickname={myNickname}
+    />
   );
 };
 

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.tsx
@@ -21,11 +21,11 @@ import type { ChatViewProps } from './ChatView.types';
 
 const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const routieSpaceUuid = getRoutieSpaceUuid() ?? '';
+  const routieSpaceUuid = getRoutieSpaceUuid();
   const messageListRef = useRef<HTMLDivElement>(null);
 
   const { messages, sendMessage } = useChat({
-    routieSpaceUuid,
+    routieSpaceUuid: routieSpaceUuid ?? '',
     accessToken,
     myNickname,
   });
@@ -36,12 +36,15 @@ const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
     }
   }, [messages]);
 
+  if (!routieSpaceUuid) return null;
+
   return (
     <>
       <div css={chatPanelStyle(isOpen)}>
         <div css={chatPanelHeaderStyle}>
           <span css={chatPanelHeaderTitleStyle}>채팅</span>
           <button
+            type="button"
             css={chatPanelCloseButtonStyle}
             onClick={() => setIsOpen(false)}
           >
@@ -59,14 +62,14 @@ const ChatView = ({ accessToken, myNickname }: ChatViewProps) => {
       </div>
 
       {!isOpen && (
-        <div
+        <button
+          type="button"
+          aria-label="채팅 열기"
           css={chatIconButtonStyle}
-          role="button"
-          tabIndex={0}
           onClick={() => setIsOpen(true)}
         >
           <Icon name="chatTab" size={36} />
-        </div>
+        </button>
       )}
     </>
   );

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.types.ts
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.types.ts
@@ -3,4 +3,8 @@ interface ChatViewProps {
   myNickname: string;
 }
 
-export type { ChatViewProps };
+interface ChatViewInnerProps extends ChatViewProps {
+  routieSpaceUuid: string;
+}
+
+export type { ChatViewProps, ChatViewInnerProps };

--- a/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.types.ts
+++ b/frontend/src/pages/RoutieSpace/components/ChatView/ChatView.types.ts
@@ -1,0 +1,6 @@
+interface ChatViewProps {
+  accessToken: string;
+  myNickname: string;
+}
+
+export type { ChatViewProps };


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->


## To-Be
#### 웹소켓 기반 채팅 UI를 구현하고 RoutieSpace에 통합했습니다.                                                                                                                                                             
                
#### 채팅 도메인                                                                                                             
- `domains/chat/types/` — STOMP 메시지 타입 정의 (CHAT, CHAT_ACK)                                                           
- `domains/chat/hooks/useChat` — WebSocket 연결 관리, 메시지 상태, 낙관적 업데이트                                          
                                                                                                                            
#### 채팅 UI                                                                                                                 
- 우측 하단 플로팅 위젯 (아이콘 클릭 → 채팅창 열기/닫기)                                                                    
- 내 메시지(파란 말풍선/오른쪽) / 상대방 메시지(회색 말풍선/왼쪽) 구분                                                      
- 고정 높이 입력창, 포커스 시 border 강조, Enter 전송 (Shift+Enter 줄바꿈)                                                  
                                                                                                                            
#### 기타                                                                                                                    
- 한국어 IME 이중 전송 버그 수정 (`isComposing` 체크)                                                                       
- 연결 전 전송 시 낙관적 메시지 자동 롤백                                                                                   
- 채팅 탭 아이콘 추가 (`allIcons`)                                                                                          
- `FeedbackWidget` → `ChatView`로 교체                                                                                      
                                                                                                                            
#### 테스트 방법                                                                                                              
                                                                                                                            
MSW mock 기준으로 동작 확인 가능합니다 (localhost에서 자동 활성화).                                                         
   
1. RoutieSpace 진입 후 우측 하단 채팅 아이콘 클릭                                                                           
2. 메시지 입력 후 Enter 또는 전송 버튼
3. 낙관적 업데이트(`...`) → CHAT_ACK 수신 후 시간 표시 확인                                                                 
4. 루티봇 에코 메시지 수신 확인 (MSW mock)   


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

https://github.com/user-attachments/assets/2a8623a2-eae7-4374-a02d-281c3b5d80d2


## (Optional) Additional Description

Closes #1106 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 채팅 추가: 채팅 패널에서 메시지 송수신 가능
  * 전송 즉시 로컬 미리보기(전송중 표시) 및 전송 완료 상태 표시
  * 메시지 타임스탬프 표기 및 중복 수신 방지
  * 플로팅 채팅 버튼으로 패널 열기/닫기, 빈 상태 안내 메시지
  * 채팅 입력 개선: Enter로 전송(Shift+Enter 줄바꿈), 스타일과 전송 버튼 UI 개선
  * 채팅 탭 아이콘 추가 및 UI 스타일 전반 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->