### PR TITLE
feat: 채팅 입력 중 및 접속 중 확인 WebSocket API 구현

### DIFF
--- a/backend/spring-routie/src/main/java/routie/business/websocket/application/PresenceRegistry.java
+++ b/backend/spring-routie/src/main/java/routie/business/websocket/application/PresenceRegistry.java
@@ -1,0 +1,85 @@
+package routie.business.websocket.application;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+import routie.business.websocket.ui.dto.response.ActiveUser;
+
+@Component
+public class PresenceRegistry {
+
+    private final Map<Long, Map<Long, ActiveUser>> roomToUsers = new ConcurrentHashMap<>();
+    private final Map<String, SubscriptionKey> subscriptionKeyBySessionSub = new ConcurrentHashMap<>();
+
+    public void addSubscription(
+            final String sessionId,
+            final String subscriptionId,
+            final Long routieSpaceId,
+            final ActiveUser user
+    ) {
+        subscriptionKeyBySessionSub.put(
+                compositeKey(sessionId, subscriptionId),
+                new SubscriptionKey(routieSpaceId, user.userId())
+        );
+        roomToUsers
+                .computeIfAbsent(routieSpaceId, id -> new ConcurrentHashMap<>())
+                .put(user.userId(), user);
+    }
+
+    public Optional<SubscriptionKey> removeSubscription(final String sessionId, final String subscriptionId) {
+        final SubscriptionKey key = subscriptionKeyBySessionSub.remove(compositeKey(sessionId, subscriptionId));
+        if (key == null) {
+            return Optional.empty();
+        }
+        removeUserFromRoom(key.routieSpaceId(), key.participantId());
+        return Optional.of(key);
+    }
+
+    public List<SubscriptionKey> removeAllForSession(final String sessionId) {
+        final String prefix = sessionId + "|";
+        final List<SubscriptionKey> removed = new ArrayList<>();
+        subscriptionKeyBySessionSub.entrySet().removeIf(entry -> {
+            if (entry.getKey().startsWith(prefix)) {
+                removed.add(entry.getValue());
+                return true;
+            }
+            return false;
+        });
+        for (final SubscriptionKey key : removed) {
+            removeUserFromRoom(key.routieSpaceId(), key.participantId());
+        }
+        return removed;
+    }
+
+    public List<ActiveUser> snapshot(final Long routieSpaceId) {
+        final Map<Long, ActiveUser> users = roomToUsers.get(routieSpaceId);
+        if (users == null) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(users.values());
+    }
+
+    private void removeUserFromRoom(final Long routieSpaceId, final Long participantId) {
+        final Map<Long, ActiveUser> users = roomToUsers.get(routieSpaceId);
+        if (users == null) {
+            return;
+        }
+        users.remove(participantId);
+        if (users.isEmpty()) {
+            roomToUsers.remove(routieSpaceId);
+        }
+    }
+
+    private String compositeKey(final String sessionId, final String subscriptionId) {
+        return sessionId + "|" + subscriptionId;
+    }
+
+    public record SubscriptionKey(Long routieSpaceId, Long participantId) {
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/business/websocket/domain/MessageType.java
+++ b/backend/spring-routie/src/main/java/routie/business/websocket/domain/MessageType.java
@@ -3,5 +3,7 @@ package routie.business.websocket.domain;
 public enum MessageType {
     CHAT,
     ENTER,
-    LEAVE
+    LEAVE,
+    TYPING,
+    PRESENCE
 }

--- a/backend/spring-routie/src/main/java/routie/business/websocket/ui/dto/request/TypingRequest.java
+++ b/backend/spring-routie/src/main/java/routie/business/websocket/ui/dto/request/TypingRequest.java
@@ -1,0 +1,7 @@
+package routie.business.websocket.ui.dto.request;
+
+public record TypingRequest(
+        Long routieSpaceId,
+        Boolean isTyping
+) {
+}

--- a/backend/spring-routie/src/main/java/routie/business/websocket/ui/dto/response/ActiveUser.java
+++ b/backend/spring-routie/src/main/java/routie/business/websocket/ui/dto/response/ActiveUser.java
@@ -1,0 +1,8 @@
+package routie.business.websocket.ui.dto.response;
+
+public record ActiveUser(
+        Long userId,
+        String userName,
+        String userRole
+) {
+}

--- a/backend/spring-routie/src/main/java/routie/business/websocket/ui/dto/response/PresenceResponse.java
+++ b/backend/spring-routie/src/main/java/routie/business/websocket/ui/dto/response/PresenceResponse.java
@@ -1,0 +1,12 @@
+package routie.business.websocket.ui.dto.response;
+
+import java.util.List;
+
+import routie.business.websocket.domain.MessageType;
+
+public record PresenceResponse(
+        MessageType type,
+        List<ActiveUser> activeUsers,
+        String timestamp
+) {
+}

--- a/backend/spring-routie/src/main/java/routie/business/websocket/ui/dto/response/TypingResponse.java
+++ b/backend/spring-routie/src/main/java/routie/business/websocket/ui/dto/response/TypingResponse.java
@@ -1,0 +1,13 @@
+package routie.business.websocket.ui.dto.response;
+
+import routie.business.websocket.domain.MessageType;
+
+public record TypingResponse(
+        MessageType type,
+        Long senderId,
+        String senderName,
+        String senderRole,
+        Boolean isTyping,
+        String timestamp
+) {
+}

--- a/backend/spring-routie/src/main/java/routie/business/websocket/ui/listener/PresenceEventListener.java
+++ b/backend/spring-routie/src/main/java/routie/business/websocket/ui/listener/PresenceEventListener.java
@@ -1,0 +1,117 @@
+package routie.business.websocket.ui.listener;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import routie.business.participant.domain.Participant;
+import routie.business.websocket.application.PresenceRegistry;
+import routie.business.websocket.application.PresenceRegistry.SubscriptionKey;
+import routie.business.websocket.domain.MessageType;
+import routie.business.websocket.ui.dto.response.ActiveUser;
+import routie.business.websocket.ui.dto.response.PresenceResponse;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PresenceEventListener {
+
+    private static final Pattern CHAT_ROOM_DESTINATION = Pattern.compile("^/topic/chat/room/(\\d+)$");
+    private static final String PARTICIPANT_SESSION_ATTRIBUTE = "participant";
+
+    private final PresenceRegistry presenceRegistry;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @EventListener
+    public void onSubscribe(final SessionSubscribeEvent event) {
+        final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        final Long routieSpaceId = extractRoutieSpaceId(accessor.getDestination());
+        if (routieSpaceId == null) {
+            return;
+        }
+
+        final Participant participant = getParticipant(accessor);
+        if (participant == null) {
+            log.warn("구독 이벤트에 participant 정보가 없습니다. sessionId: {}", accessor.getSessionId());
+            return;
+        }
+
+        final ActiveUser user = new ActiveUser(
+                participant.getId(),
+                participant.getNickname(),
+                participant.getRole().name()
+        );
+        presenceRegistry.addSubscription(
+                accessor.getSessionId(),
+                accessor.getSubscriptionId(),
+                routieSpaceId,
+                user
+        );
+        broadcastPresence(routieSpaceId);
+    }
+
+    @EventListener
+    public void onUnsubscribe(final SessionUnsubscribeEvent event) {
+        final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        presenceRegistry.removeSubscription(accessor.getSessionId(), accessor.getSubscriptionId())
+                .ifPresent(key -> broadcastPresence(key.routieSpaceId()));
+    }
+
+    @EventListener
+    public void onDisconnect(final SessionDisconnectEvent event) {
+        final List<SubscriptionKey> removed = presenceRegistry.removeAllForSession(event.getSessionId());
+        final Set<Long> affectedRooms = new HashSet<>();
+        for (final SubscriptionKey key : removed) {
+            affectedRooms.add(key.routieSpaceId());
+        }
+        for (final Long routieSpaceId : affectedRooms) {
+            broadcastPresence(routieSpaceId);
+        }
+    }
+
+    private void broadcastPresence(final Long routieSpaceId) {
+        final PresenceResponse response = new PresenceResponse(
+                MessageType.PRESENCE,
+                presenceRegistry.snapshot(routieSpaceId),
+                Instant.now().toString()
+        );
+        messagingTemplate.convertAndSend("/topic/chat/room/" + routieSpaceId, response);
+    }
+
+    private Long extractRoutieSpaceId(final String destination) {
+        if (destination == null) {
+            return null;
+        }
+        final Matcher matcher = CHAT_ROOM_DESTINATION.matcher(destination);
+        if (!matcher.matches()) {
+            return null;
+        }
+        return Long.parseLong(matcher.group(1));
+    }
+
+    private Participant getParticipant(final StompHeaderAccessor accessor) {
+        final Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes == null) {
+            return null;
+        }
+        final Object value = sessionAttributes.get(PARTICIPANT_SESSION_ATTRIBUTE);
+        if (value instanceof Participant participant) {
+            return participant;
+        }
+        return null;
+    }
+}

--- a/backend/spring-routie/src/main/java/routie/business/websocket/ui/v1/ChatControllerV1.java
+++ b/backend/spring-routie/src/main/java/routie/business/websocket/ui/v1/ChatControllerV1.java
@@ -11,8 +11,13 @@ import routie.business.authentication.ui.argument.annotation.AuthenticatedPartic
 import routie.business.participant.domain.Participant;
 import routie.business.websocket.application.ChatService;
 import routie.business.websocket.domain.ChatMessage;
+import routie.business.websocket.domain.MessageType;
 import routie.business.websocket.ui.dto.request.ChatRequest;
+import routie.business.websocket.ui.dto.request.TypingRequest;
 import routie.business.websocket.ui.dto.response.ChatResponse;
+import routie.business.websocket.ui.dto.response.TypingResponse;
+
+import java.time.Instant;
 
 @Slf4j
 @Controller
@@ -46,6 +51,28 @@ public class ChatControllerV1 {
                 senderName,
                 savedMessage.getContent(),
                 savedMessage.getCreatedAt()
+        );
+    }
+
+    @MessageMapping("/chat/room/{routieSpaceId}/typing")
+    @SendTo("/topic/chat/room/{routieSpaceId}")
+    public TypingResponse typing(
+            @DestinationVariable("routieSpaceId") final Long routieSpaceId,
+            @AuthenticatedParticipant final Participant participant,
+            @Payload final TypingRequest request
+    ) {
+        log.info(
+                "타이핑 이벤트 Space ID: {}, Sender: {}, isTyping: {}",
+                routieSpaceId, participant.getId(), request.isTyping()
+        );
+
+        return new TypingResponse(
+                MessageType.TYPING,
+                participant.getId(),
+                participant.getNickname(),
+                participant.getRole().name(),
+                request.isTyping(),
+                Instant.now().toString()
         );
     }
 }

--- a/backend/spring-routie/src/test/java/routie/business/websocket/ui/v1/ChatControllerV1Test.java
+++ b/backend/spring-routie/src/test/java/routie/business/websocket/ui/v1/ChatControllerV1Test.java
@@ -27,7 +27,8 @@ import routie.business.routiespace.domain.RoutieSpaceRepository;
 import routie.business.websocket.domain.ChatMessageRepository;
 import routie.business.websocket.domain.MessageType;
 import routie.business.websocket.ui.dto.request.ChatRequest;
-import routie.business.websocket.ui.dto.response.ChatResponse;
+
+import java.util.Map;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import java.lang.reflect.Type;
@@ -92,7 +93,7 @@ public class ChatControllerV1Test {
         );
         final String jwt = jwtProcessor.createJwt(user);
 
-        final BlockingQueue<ChatResponse> blockingQueue = new LinkedBlockingQueue<>();
+        final BlockingQueue<Map<String, Object>> blockingQueue = new LinkedBlockingQueue<>();
         final String wsUrl = "ws://localhost:" + port + "/ws/v1";
 
         // CONNECT 헤더에 토큰 삽입
@@ -118,12 +119,13 @@ public class ChatControllerV1Test {
                 subscribeDestination, new StompFrameHandler() {
                     @Override
                     public Type getPayloadType(final StompHeaders headers) {
-                        return ChatResponse.class;
+                        return Map.class;
                     }
 
                     @Override
+                    @SuppressWarnings("unchecked")
                     public void handleFrame(final StompHeaders headers, final Object payload) {
-                        blockingQueue.add((ChatResponse) payload);
+                        blockingQueue.add((Map<String, Object>) payload);
                     }
                 }
         );
@@ -143,14 +145,27 @@ public class ChatControllerV1Test {
         session.send(stompHeaders, request);
 
         // then
-        final ChatResponse response = blockingQueue.poll(5, TimeUnit.SECONDS);
+        Map<String, Object> response = null;
+        final long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            final Map<String, Object> message = blockingQueue.poll(
+                    Math.max(1, deadline - System.currentTimeMillis()), TimeUnit.MILLISECONDS
+            );
+            if (message == null) {
+                break;
+            }
+            if (MessageType.CHAT.name().equals(message.get("type"))) {
+                response = message;
+                break;
+            }
+        }
 
         assertThat(response).isNotNull();
-        assertThat(response.content()).isEqualTo("통합테스트 메시지");
-        assertThat(response.senderId()).isEqualTo(user.getId());
-        assertThat(response.senderRole()).isEqualTo(Role.USER.name());
-        assertThat(response.type()).isEqualTo(MessageType.CHAT.name());
-        assertThat(response.tempId()).isEqualTo("temp-10");
-        assertThat(response.senderName()).isEqualTo(user.getNickname());
+        assertThat(response.get("content")).isEqualTo("통합테스트 메시지");
+        assertThat(((Number) response.get("senderId")).longValue()).isEqualTo(user.getId());
+        assertThat(response.get("senderRole")).isEqualTo(Role.USER.name());
+        assertThat(response.get("type")).isEqualTo(MessageType.CHAT.name());
+        assertThat(response.get("tempId")).isEqualTo("temp-10");
+        assertThat(response.get("senderName")).isEqualTo(user.getNickname());
     }
 }


### PR DESCRIPTION
## As-Is
- 채팅방에서 유저의 타이핑 상태와 접속 여부를 알 수 없음

## To-Be
WebSocket Messages 명세서의 세 가지 API를 구현한다.

- **채팅 입력 중 발행** `/app/chat/room/{routieSpaceId}/typing` (PUB)
- **채팅 입력 중 브로드캐스트** `/topic/chat/room/{routieSpaceId}` (`type: TYPING`)
- **접속 중 확인 브로드캐스트** `/topic/chat/room/{routieSpaceId}` (`type: PRESENCE`)

### 변경 사항
- `MessageType` enum에 `TYPING`, `PRESENCE` 추가
- `TypingRequest` / `TypingResponse` / `PresenceResponse` / `ActiveUser` DTO 추가
- `ChatControllerV1`에 `/typing` 핸들러 추가 (DB 저장 없이 브로드캐스트만)
- `PresenceRegistry` 추가: 방별 접속자와 `sessionId|subscriptionId` → (방, 참여자) 역참조 맵을 `ConcurrentHashMap`으로 관리 (in-memory)
- `PresenceEventListener` 추가: `SessionSubscribeEvent` / `SessionUnsubscribeEvent` / `SessionDisconnectEvent`를 받아 `/topic/chat/room/{id}` 패턴에서만 presence 업데이트 후 `PRESENCE` 브로드캐스트

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
로컬 STOMP 클라이언트 두 개로 다음 플로우 검증 완료:
1. 두 탭 접속 → 양쪽에 `PRESENCE`(activeUsers 2명) 수신
2. 타이핑 발행 → 양쪽에 `TYPING` 수신
3. 한 탭 disconnect → 남은 탭에 `PRESENCE`(activeUsers 1명) 수신

## (Optional) Additional Description

Closes #1125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 실시간 타이핑 표시 기능 추가: 사용자가 채팅방에서 다른 사용자가 메시지를 입력 중임을 확인할 수 있습니다.
  * 활성 사용자 목록 추가: 채팅방에 현재 접속한 사용자 목록을 실시간으로 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->